### PR TITLE
Efficient previous version

### DIFF
--- a/include/cascade/cascade.hpp
+++ b/include/cascade/cascade.hpp
@@ -436,6 +436,9 @@ namespace cascade {
 
     /**
      * The VT template type of PersistentCascadeStore/VolatileCascadeStore must implement ICascadeObject interface.
+     * We use both the concepts of null and valid object in Cascade. A null object precisely means 'no data'; while a
+     * valid object literarily means an object is 'valid'. Technically, a null object has a valid key while invalid
+     * object does not.
      */
     template <typename KT>
     class ICascadeObject {
@@ -456,6 +459,14 @@ namespace cascade {
          * @return true for null object
          */
         virtual bool is_null() const = 0;
+        /**
+         * is_valid()
+         *
+         * Test if this Object is valid or not.
+         *
+         * @ return true for invalid object
+         */
+        virtual bool is_valid() const = 0;
     };
 
     /**

--- a/include/cascade/cascade.hpp
+++ b/include/cascade/cascade.hpp
@@ -407,6 +407,11 @@ namespace cascade {
          * @param ver   The current version
          */
         virtual void set_version(persistent::version_t ver) const = 0;
+        /**
+         * get_version returns the version
+         * @return the VT's version
+         */
+        virtual persistent::version_t get_version() const = 0;
     };
 
     /**
@@ -421,6 +426,10 @@ namespace cascade {
          * @param ts_us The timestamp in microseconds
          */
         virtual void set_timestamp(uint64_t ts_us) const = 0;
+        /**
+         * get_timestamp() returns VT's timestamp
+         */
+        virtual uint64_t get_timestamp() const = 0;
     };
 
     /**

--- a/include/cascade/cascade.hpp
+++ b/include/cascade/cascade.hpp
@@ -396,6 +396,34 @@ namespace cascade {
      */
 
     /**
+     * TODO:
+     * If the VT template type of PersistentCascadeStore/VolatileCascadeStore implements IKeepVersion interface, its
+     * 'set_version' method will be called on 'ordered_put' or 'ordered_remove' with the current version assigned to
+     * this operation. The VT implementer may save this version in its states.
+     */
+    class IKeepVersion {
+        /**
+         * set_version() is a callback on PersistentCascadeStore/VolatileCascadeStore updates.
+         * @param ver   The current version
+         */
+        virtual void set_version(persistent::version_t ver) const = 0;
+    };
+
+    /**
+     * TODO:
+     * If the VT template type of PersistentCascadeStore/VolatileCascadeStore implements IKeepTimestamp interface, its
+     * 'set_timestamp' method will be called on updates with the timestamp in microseconds assigned to this operation.
+     * The VT implementer may save this timestamp in its states.
+     */
+    class IKeepTimestamp {
+        /**
+         * set_timestamp() is a callback on PersistentCascadeStore/VolatileCascadeStore updates.
+         * @param ts_us The timestamp in microseconds
+         */
+        virtual void set_timestamp(uint64_t ts_us) const = 0;
+    };
+
+    /**
      * If the VT template type of PersistentCascadeStore implements IKeepPreviousVersion interface, its
      * 'set_previous_version' method will be called on 'ordered_put' with the previous version in the shard as well as
      * the previous version of the same key. If this is the first value of that key, 'set_previous_version' will be
@@ -409,7 +437,7 @@ namespace cascade {
          * @param prev_ver          The previous version
          * @param prev_ver_by_key   The previous version of the same key in VT object
          */
-        virtual void set_previous_version(persistent::version_t& prev_ver, persistent::version_t& perv_ver_by_key) = 0;
+        virtual void set_previous_version(persistent::version_t prev_ver, persistent::version_t perv_ver_by_key) const = 0;
     };
 
     /**
@@ -434,7 +462,7 @@ namespace cascade {
          * @param prev_ver          The previous version
          * @param prev_ver_by_key   The previous version of the same key in VT object
          */
-        virtual bool verify_previous_version(persistent::version_t& prev_ver, persistent::version_t& prev_ver_by_key) = 0;
+        virtual bool verify_previous_version(persistent::version_t prev_ver, persistent::version_t prev_ver_by_key) const = 0;
     };
 
 } // namespace cascade

--- a/include/cascade/cascade.hpp
+++ b/include/cascade/cascade.hpp
@@ -246,6 +246,12 @@ namespace cascade {
                                   public persistent::IDeltaSupport<DeltaCascadeStoreCore<KT,VT,IK,IV>> {
         // TODO: use max payload size in subgroup configuration.
 #define DEFAULT_DELTA_BUFFER_CAPACITY (4096)
+        /**
+         * Initialize the delta data structure.
+         */
+        void initialize_delta();
+
+    public:
         enum _OPID {
             PUT,
             REMOVE
@@ -265,13 +271,12 @@ namespace cascade {
             inline void destroy();
         } _Delta;
         _Delta delta;
-        
-        /**
-         * Initialize the delta data structure.
-         */
-        void initialize_delta();
 
-    public:
+        struct DeltaBytesFormat {
+            uint32_t    op;
+            char        first_data_byte;
+        };
+        
         std::map<KT,VT> kv_map;
 
         //////////////////////////////////////////////////////////////////////////
@@ -394,6 +399,22 @@ namespace cascade {
     /**
      * Interfaces for ValueTypes, derive them to enable corresponding features.
      */
+
+    /**
+     * The VT template type of PersistentCascadeStore/VolatileCascadeStore must implement ICascadeObject interface.
+     */
+    template <typename KT>
+    class ICascadeObject {
+    public:
+        /**
+         * get_key_ref()
+         *
+         * Get a const reference to the key.
+         *
+         * @return a const reference to the key
+         */
+        virtual const KT& get_key_ref() const = 0;
+    };
 
     /**
      * TODO:

--- a/include/cascade/cascade.hpp
+++ b/include/cascade/cascade.hpp
@@ -225,6 +225,8 @@ namespace cascade {
         using derecho::GroupReference::group;
         /* volatile cascade store in memory */
         std::map<KT,VT> kv_map;
+        /* record the version of latest update */
+        persistent::version_t update_version;
         /* watcher */
         CascadeWatcher<KT,VT,IK,IV>* cascade_watcher_ptr;
         
@@ -257,7 +259,7 @@ namespace cascade {
         virtual uint64_t ordered_get_size(const KT& key) override;
 
         // serialization support
-        DEFAULT_SERIALIZE(kv_map);
+        DEFAULT_SERIALIZE(kv_map,update_version);
 
         static std::unique_ptr<VolatileCascadeStore> from_bytes(mutils::DeserializationManager* dsm, char const* buf);
 
@@ -267,8 +269,8 @@ namespace cascade {
 
         /* constructors */
         VolatileCascadeStore(CascadeWatcher<KT,VT,IK,IV>* cw=nullptr);
-        VolatileCascadeStore(const std::map<KT,VT>& _kvm, CascadeWatcher<KT,VT,IK,IV>* cw=nullptr); // copy kv_map
-        VolatileCascadeStore(std::map<KT,VT>&& _kvm, CascadeWatcher<KT,VT,IK,IV>* cw=nullptr); // move kv_map
+        VolatileCascadeStore(const std::map<KT,VT>& _kvm, persistent::version_t _uv, CascadeWatcher<KT,VT,IK,IV>* cw=nullptr); // copy kv_map
+        VolatileCascadeStore(std::map<KT,VT>&& _kvm, persistent::version_t _uv, CascadeWatcher<KT,VT,IK,IV>* cw=nullptr); // move kv_map
     };
 
     /**

--- a/include/cascade/detail/cascade_impl.hpp
+++ b/include/cascade/detail/cascade_impl.hpp
@@ -581,6 +581,10 @@ std::tuple<persistent::version_t,uint64_t> PersistentCascadeStore<KT,VT,IK,IV,ST
 
     std::tuple<persistent::version_t,uint64_t> version = group->template get_subgroup<PersistentCascadeStore>(this->subgroup_index).get_next_version();
     value.ver = version;
+    if constexpr (std::is_base_of<IKeepPreviousVersion,VT>::value) {
+        auto prev = this->persistent_core->ordered_get(value.key);
+        value.set_previous_version(persistent_core.getLatestVersion(),std::get<0>(prev.ver));
+    }
     this->persistent_core->ordered_put(value);
     if (cascade_watcher_ptr) {
         (*cascade_watcher_ptr)(

--- a/include/cascade/detail/cascade_impl.hpp
+++ b/include/cascade/detail/cascade_impl.hpp
@@ -381,7 +381,7 @@ bool DeltaCascadeStoreCore<KT,VT,IK,IV>::ordered_remove(const VT& value, persist
     // create delta.
     assert(this->delta.is_empty());
     this->delta.calibrate(mutils::bytes_size(value));
-    mutils::to_bytes(key,this->delta.data_ptr());
+    mutils::to_bytes(value,this->delta.data_ptr());
     this->delta.set_data_len(mutils::bytes_size(value));
     // apply_ordered_put
     apply_ordered_put(value);

--- a/include/cascade/detail/cascade_impl.hpp
+++ b/include/cascade/detail/cascade_impl.hpp
@@ -471,6 +471,7 @@ template<typename KT, typename VT, KT* IK, VT* IV, persistent::StorageType ST>
 const VT PersistentCascadeStore<KT,VT,IK,IV,ST>::get(const KT& key, const persistent::version_t& ver) {
     debug_enter_func_with_args("key={},ver=0x{:x}",key,ver);
     if (ver != CURRENT_VERSION) {
+        debug_leave_func();
         return persistent_core.get(ver)->kv_map.at(key);
     }
     derecho::Replicated<PersistentCascadeStore>& subgroup_handle = group->template get_subgroup<PersistentCascadeStore>(this->subgroup_index);

--- a/include/cascade/detail/service_impl.hpp
+++ b/include/cascade/detail/service_impl.hpp
@@ -272,7 +272,7 @@ derecho::rpc::QueryResults<const typename SubgroupType::ObjectType> ServiceClien
         uint32_t shard_index) {
     auto& caller = external_group.template get_subgroup_caller<SubgroupType>(subgroup_index);
     node_id_t node_id = pick_member_by_policy<SubgroupType>(subgroup_index,shard_index);
-    return caller.template p2p_send<RPC_NAME(get)>(node_id,key,version,false); // TODO:
+    return caller.template p2p_send<RPC_NAME(get)>(node_id,key,version,false); 
 }
 
 template <typename... CascadeTypes>

--- a/include/cascade/detail/service_impl.hpp
+++ b/include/cascade/detail/service_impl.hpp
@@ -272,7 +272,7 @@ derecho::rpc::QueryResults<const typename SubgroupType::ObjectType> ServiceClien
         uint32_t shard_index) {
     auto& caller = external_group.template get_subgroup_caller<SubgroupType>(subgroup_index);
     node_id_t node_id = pick_member_by_policy<SubgroupType>(subgroup_index,shard_index);
-    return caller.template p2p_send<RPC_NAME(get)>(node_id,key,version);
+    return caller.template p2p_send<RPC_NAME(get)>(node_id,key,version,false); // TODO:
 }
 
 template <typename... CascadeTypes>
@@ -296,7 +296,7 @@ derecho::rpc::QueryResults<uint64_t> ServiceClient<CascadeTypes...>::get_size(
         uint32_t shard_index) {
     auto& caller = external_group.template get_subgroup_caller<SubgroupType>(subgroup_index);
     node_id_t node_id = pick_member_by_policy<SubgroupType>(subgroup_index,shard_index);
-    return caller.template p2p_send<RPC_NAME(get_size)>(node_id,key,version);
+    return caller.template p2p_send<RPC_NAME(get_size)>(node_id,key,version,false);
 }
 
 template <typename... CascadeTypes>

--- a/include/cascade/object.hpp
+++ b/include/cascade/object.hpp
@@ -78,6 +78,7 @@ class ObjectWithUInt64Key : public mutils::ByteRepresentable,
 public:
     mutable persistent::version_t                       version;
     mutable uint64_t                                    timestamp_us;
+    mutable persistent::version_t                       previous_version; // previous version, INVALID_VERSION for the first version
     mutable persistent::version_t                       previous_version_by_key; // previous version by key, INVALID_VERSION for the first value of the key.
     uint64_t                                            key; // object_id
     Blob                                                blob; // the object
@@ -91,6 +92,7 @@ public:
     // constructor 0.5 : copy constructor
     ObjectWithUInt64Key(const persistent::version_t _version,
                         const uint64_t _timestamp_us,
+                        const persistent::version_t _previous_version,
                         const persistent::version_t _previous_version_by_key,
                         const uint64_t _key,
                         const Blob& _blob);
@@ -103,6 +105,7 @@ public:
     // constructor 1.5 : copy constructor
     ObjectWithUInt64Key(const persistent::version_t _version,
                         const uint64_t _timestamp_us,
+                        const persistent::version_t _previous_version,
                         const persistent::version_t _previous_version_by_key,
                         const uint64_t _key,
                         const char* const _b,
@@ -122,13 +125,13 @@ public:
     virtual const uint64_t& get_key_ref() const override;
     virtual bool is_null() const override;
     virtual bool is_valid() const override;
-    virtual void set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const override;
+    virtual void set_previous_version(persistent::version_t prev_ver, persistent::version_t prev_ver_by_key) const override;
     virtual void set_version(persistent::version_t ver) const override;
     virtual persistent::version_t get_version() const override;
     virtual void set_timestamp(uint64_t ts_us) const override;
     virtual uint64_t get_timestamp() const override;
 
-    DEFAULT_SERIALIZATION_SUPPORT(ObjectWithUInt64Key, version, timestamp_us, previous_version_by_key, key, blob);
+    DEFAULT_SERIALIZATION_SUPPORT(ObjectWithUInt64Key, version, timestamp_us, previous_version, previous_version_by_key, key, blob);
 
     // IK and IV for volatile cascade store
     static uint64_t IK;
@@ -153,7 +156,8 @@ inline std::ostream& operator<<(std::ostream& out, const Blob& b) {
 inline std::ostream& operator<<(std::ostream& out, const ObjectWithUInt64Key& o) {
     out << "ObjectWithUInt64Key{ver: 0x" << std::hex << o.version << std::dec 
         << ", ts(us): " << o.timestamp_us 
-        << ", prev_ver: " << std::hex << o.previous_version_by_key << std::dec
+        << ", prev_ver: " << std::hex << o.previous_version << std::dec
+        << ", prev_ver_by_key: " << std::hex << o.previous_version_by_key << std::dec
         << ", id:" << o.key 
         << ", data:" << o.blob << "}";
     return out;
@@ -166,6 +170,7 @@ class ObjectWithStringKey : public mutils::ByteRepresentable,
 public:
     mutable persistent::version_t                       version;                // object version
     mutable uint64_t                                    timestamp_us;           // timestamp in microsecond
+    mutable persistent::version_t                       previous_version;       // previous version, INVALID_VERSION for the first version.
     mutable persistent::version_t                       previous_version_by_key; // previous version by key, INVALID_VERSION for the first value of the key.
     std::string                                         key;                     // object_id
     Blob                                                blob;                    // the object data
@@ -179,6 +184,7 @@ public:
     // constructor 0.5 : copy constructor
     ObjectWithStringKey(const persistent::version_t _version,
                         const uint64_t _timestamp_us,
+                        const persistent::version_t _previous_version,
                         const persistent::version_t _previous_version_by_key,
                         const std::string& _key,
                         const Blob& _blob);
@@ -191,6 +197,7 @@ public:
     // constructor 1.5 : copy constructor
     ObjectWithStringKey(const persistent::version_t _version,
                         const uint64_t _timestamp_us,
+                        const persistent::version_t _previous_version,
                         const persistent::version_t _previous_version_by_key,
                         const std::string& _key,
                         const char* const _b,
@@ -210,13 +217,13 @@ public:
     virtual const std::string& get_key_ref() const override;
     virtual bool is_null() const override;
     virtual bool is_valid() const override;
-    virtual void set_previous_version(persistent::version_t, persistent::version_t perv_ver_by_key) const override;
+    virtual void set_previous_version(persistent::version_t prev_ver, persistent::version_t perv_ver_by_key) const override;
     virtual void set_version(persistent::version_t ver) const override;
     virtual persistent::version_t get_version() const override;
     virtual void set_timestamp(uint64_t ts_us) const override;
     virtual uint64_t get_timestamp() const override;
 
-    DEFAULT_SERIALIZATION_SUPPORT(ObjectWithStringKey, version, timestamp_us, previous_version_by_key, key, blob);
+    DEFAULT_SERIALIZATION_SUPPORT(ObjectWithStringKey, version, timestamp_us, previous_version, previous_version_by_key, key, blob);
 
     // IK and IV for volatile cascade store
     static std::string IK;
@@ -226,11 +233,13 @@ public:
 inline std::ostream& operator<<(std::ostream& out, const ObjectWithStringKey& o) {
     out << "ObjectWithStringKey{ver: 0x" << std::hex << o.version << std::dec 
         << ", ts: " << o.timestamp_us
-        << ", prev_ver: " << std::hex << o.previous_version_by_key << std::dec
+        << ", prev_ver: " << std::hex << o.previous_version << std::dec
+        << ", prev_ver_by_key: " << std::hex << o.previous_version_by_key << std::dec
         << ", id:" << o.key 
         << ", data:" << o.blob << "}";
     return out;
 }
+
 /**
 template <typename KT, typename VT, KT* IK, VT* IV>
 std::enable_if_t<std::disjunction<std::is_same<ObjectWithStringKey,VT>,std::is_same<ObjectWithStringKey,VT>>::value, VT> create_null_object_cb(const KT& key) {

--- a/include/cascade/object.hpp
+++ b/include/cascade/object.hpp
@@ -72,6 +72,7 @@ public:
 #define INVALID_UINT64_OBJECT_KEY (0xffffffffffffffffLLU)
 
 class ObjectWithUInt64Key : public mutils::ByteRepresentable,
+                            public ICascadeObject<uint64_t>,
                             public IKeepVersion,
                             public IKeepTimestamp,
                             public IKeepPreviousVersion {
@@ -121,6 +122,7 @@ public:
     // constructor 4 : default invalid constructor
     ObjectWithUInt64Key();
 
+    virtual const uint64_t& get_key_ref() const override;
     virtual void set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const override;
     virtual void set_version(persistent::version_t ver) const override;
     virtual persistent::version_t get_version() const override;
@@ -159,6 +161,7 @@ inline std::ostream& operator<<(std::ostream& out, const ObjectWithUInt64Key& o)
 }
 
 class ObjectWithStringKey : public mutils::ByteRepresentable,
+                            public ICascadeObject<std::string>,
                             public IKeepVersion,
                             public IKeepTimestamp,
                             public IKeepPreviousVersion {
@@ -208,6 +211,7 @@ public:
     // constructor 4 : default invalid constructor
     ObjectWithStringKey();
 
+    virtual const std::string& get_key_ref() const override;
     virtual void set_previous_version(persistent::version_t, persistent::version_t perv_ver_by_key) const override;
     virtual void set_version(persistent::version_t ver) const override;
     virtual persistent::version_t get_version() const override;

--- a/include/cascade/object.hpp
+++ b/include/cascade/object.hpp
@@ -72,38 +72,41 @@ public:
 #define INVALID_UINT64_OBJECT_KEY (0xffffffffffffffffLLU)
 
 class ObjectWithUInt64Key : public mutils::ByteRepresentable,
+                            public IKeepVersion,
+                            public IKeepTimestamp,
                             public IKeepPreviousVersion {
 public:
-    mutable std::tuple<persistent::version_t,uint64_t> ver; // object version
-    uint64_t                                           key; // object_id
-    mutable persistent::version_t                      previous_version_by_key; // previous version by key, INVALID_VERSION for the first value of the key.
-    Blob                                               blob; // the object
+    mutable persistent::version_t                       version;
+    mutable uint64_t                                    timestamp_us;
+    mutable persistent::version_t                       previous_version_by_key; // previous version by key, INVALID_VERSION for the first value of the key.
+    uint64_t                                            key; // object_id
+    Blob                                                blob; // the object
 
     bool operator==(const ObjectWithUInt64Key& other);
 
     bool is_valid() const;
 
     // constructor 0 : copy constructor
-    ObjectWithUInt64Key(const uint64_t& _key, 
-                        const persistent::version_t& _previous_version_by_key,
+    ObjectWithUInt64Key(const uint64_t _key, 
                         const Blob& _blob);
 
     // constructor 0.5 : copy constructor
-    ObjectWithUInt64Key(const std::tuple<persistent::version_t,uint64_t> _ver,
-                        const uint64_t& _key,
-                        const persistent::version_t& _previous_version_by_key,
+    ObjectWithUInt64Key(const persistent::version_t _version,
+                        const uint64_t _timestamp_us,
+                        const persistent::version_t _previous_version_by_key,
+                        const uint64_t _key,
                         const Blob& _blob);
 
-    // constructor 1 : copy consotructor
+    // constructor 1 : copy constructor
     ObjectWithUInt64Key(const uint64_t _key,
-                        const persistent::version_t& _previous_version_by_key,
                         const char* const _b,
                         const std::size_t _s);
 
     // constructor 1.5 : copy constructor
-    ObjectWithUInt64Key(const std::tuple<persistent::version_t,uint64_t> _ver,
+    ObjectWithUInt64Key(const persistent::version_t _version,
+                        const uint64_t _timestamp_us,
+                        const persistent::version_t _previous_version_by_key,
                         const uint64_t _key,
-                        const persistent::version_t& _previous_version_by_key,
                         const char* const _b,
                         const std::size_t _s);
 
@@ -119,8 +122,12 @@ public:
     ObjectWithUInt64Key();
 
     virtual void set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const override;
+    virtual void set_version(persistent::version_t ver) const override;
+    virtual persistent::version_t get_version() const override;
+    virtual void set_timestamp(uint64_t ts_us) const override;
+    virtual uint64_t get_timestamp() const override;
 
-    DEFAULT_SERIALIZATION_SUPPORT(ObjectWithUInt64Key, ver, key, previous_version_by_key, blob);
+    DEFAULT_SERIALIZATION_SUPPORT(ObjectWithUInt64Key, version, timestamp_us, previous_version_by_key, key, blob);
 
     // IK and IV for volatile cascade store
     static uint64_t IK;
@@ -143,8 +150,8 @@ inline std::ostream& operator<<(std::ostream& out, const Blob& b) {
 }
 
 inline std::ostream& operator<<(std::ostream& out, const ObjectWithUInt64Key& o) {
-    out << "ObjectWithUInt64Key{ver: 0x" << std::hex << std::get<0>(o.ver) << std::dec 
-        << ", ts: " << std::get<1>(o.ver) 
+    out << "ObjectWithUInt64Key{ver: 0x" << std::hex << o.version << std::dec 
+        << ", ts(us): " << o.timestamp_us 
         << ", prev_ver: " << std::hex << o.previous_version_by_key << std::dec
         << ", id:" << o.key 
         << ", data:" << o.blob << "}";
@@ -152,12 +159,15 @@ inline std::ostream& operator<<(std::ostream& out, const ObjectWithUInt64Key& o)
 }
 
 class ObjectWithStringKey : public mutils::ByteRepresentable,
+                            public IKeepVersion,
+                            public IKeepTimestamp,
                             public IKeepPreviousVersion {
 public:
-    mutable std::tuple<persistent::version_t,uint64_t> ver;                     // object version
-    std::string                                        key;                     // object_id
-    mutable persistent::version_t                      previous_version_by_key; // previous version by key, INVALID_VERSION for the first value of the key.
-    Blob                                               blob;                    // the object data
+    mutable persistent::version_t                       version;                // object version
+    mutable uint64_t                                    timestamp_us;           // timestamp in microsecond
+    mutable persistent::version_t                       previous_version_by_key; // previous version by key, INVALID_VERSION for the first value of the key.
+    std::string                                         key;                     // object_id
+    Blob                                                blob;                    // the object data
 
     bool operator==(const ObjectWithStringKey& other);
 
@@ -165,25 +175,25 @@ public:
 
     // constructor 0 : copy constructor
     ObjectWithStringKey(const std::string& _key, 
-                        const persistent::version_t& _previous_version_by_key,
                         const Blob& _blob);
 
     // constructor 0.5 : copy constructor
-    ObjectWithStringKey(const std::tuple<persistent::version_t,uint64_t> _ver,
+    ObjectWithStringKey(const persistent::version_t _version,
+                        const uint64_t _timestamp_us,
+                        const persistent::version_t _previous_version_by_key,
                         const std::string& _key,
-                        const persistent::version_t& _previous_version_by_key,
                         const Blob& _blob);
 
     // constructor 1 : copy consotructor
     ObjectWithStringKey(const std::string& _key,
-                        const persistent::version_t& _previous_version_by_key,
                         const char* const _b,
                         const std::size_t _s);
 
     // constructor 1.5 : copy constructor
-    ObjectWithStringKey(const std::tuple<persistent::version_t,uint64_t> _ver,
+    ObjectWithStringKey(const persistent::version_t _version,
+                        const uint64_t _timestamp_us,
+                        const persistent::version_t _previous_version_by_key,
                         const std::string& _key,
-                        const persistent::version_t& _previous_version_by_key,
                         const char* const _b,
                         const std::size_t _s);
 
@@ -198,9 +208,13 @@ public:
     // constructor 4 : default invalid constructor
     ObjectWithStringKey();
 
-    virtual void set_previous_version(persistent::version_t, persistent::version_t perv_ver_by_key)const override;
+    virtual void set_previous_version(persistent::version_t, persistent::version_t perv_ver_by_key) const override;
+    virtual void set_version(persistent::version_t ver) const override;
+    virtual persistent::version_t get_version() const override;
+    virtual void set_timestamp(uint64_t ts_us) const override;
+    virtual uint64_t get_timestamp() const override;
 
-    DEFAULT_SERIALIZATION_SUPPORT(ObjectWithStringKey, ver, key, previous_version_by_key, blob);
+    DEFAULT_SERIALIZATION_SUPPORT(ObjectWithStringKey, version, timestamp_us, previous_version_by_key, key, blob);
 
     // IK and IV for volatile cascade store
     static std::string IK;
@@ -208,8 +222,8 @@ public:
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ObjectWithStringKey& o) {
-    out << "ObjectWithStringKey{ver: 0x" << std::hex << std::get<0>(o.ver) << std::dec 
-        << ", ts: " << std::get<1>(o.ver) 
+    out << "ObjectWithStringKey{ver: 0x" << std::hex << o.version << std::dec 
+        << ", ts: " << o.timestamp_us
         << ", prev_ver: " << std::hex << o.previous_version_by_key << std::dec
         << ", id:" << o.key 
         << ", data:" << o.blob << "}";

--- a/include/cascade/object.hpp
+++ b/include/cascade/object.hpp
@@ -73,7 +73,6 @@ public:
 
 class ObjectWithUInt64Key : public mutils::ByteRepresentable,
                             public ICascadeObject<uint64_t>,
-                            public IKeepVersion,
                             public IKeepTimestamp,
                             public IKeepPreviousVersion {
 public:
@@ -123,6 +122,7 @@ public:
     ObjectWithUInt64Key();
 
     virtual const uint64_t& get_key_ref() const override;
+    virtual bool is_null() const override;
     virtual void set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const override;
     virtual void set_version(persistent::version_t ver) const override;
     virtual persistent::version_t get_version() const override;
@@ -162,7 +162,6 @@ inline std::ostream& operator<<(std::ostream& out, const ObjectWithUInt64Key& o)
 
 class ObjectWithStringKey : public mutils::ByteRepresentable,
                             public ICascadeObject<std::string>,
-                            public IKeepVersion,
                             public IKeepTimestamp,
                             public IKeepPreviousVersion {
 public:
@@ -212,6 +211,7 @@ public:
     ObjectWithStringKey();
 
     virtual const std::string& get_key_ref() const override;
+    virtual bool is_null() const override;
     virtual void set_previous_version(persistent::version_t, persistent::version_t perv_ver_by_key) const override;
     virtual void set_version(persistent::version_t ver) const override;
     virtual persistent::version_t get_version() const override;
@@ -233,6 +233,12 @@ inline std::ostream& operator<<(std::ostream& out, const ObjectWithStringKey& o)
         << ", data:" << o.blob << "}";
     return out;
 }
+/**
+template <typename KT, typename VT, KT* IK, VT* IV>
+std::enable_if_t<std::disjunction<std::is_same<ObjectWithStringKey,VT>,std::is_same<ObjectWithStringKey,VT>>::value, VT> create_null_object_cb(const KT& key) {
+    return VT(key,Blob{});
+}
+**/
 
 } // namespace cascade
 } // namespace derecho

--- a/include/cascade/object.hpp
+++ b/include/cascade/object.hpp
@@ -82,9 +82,7 @@ public:
     uint64_t                                            key; // object_id
     Blob                                                blob; // the object
 
-    bool operator==(const ObjectWithUInt64Key& other);
-
-    bool is_valid() const;
+    // bool operator==(const ObjectWithUInt64Key& other);
 
     // constructor 0 : copy constructor
     ObjectWithUInt64Key(const uint64_t _key, 
@@ -123,6 +121,7 @@ public:
 
     virtual const uint64_t& get_key_ref() const override;
     virtual bool is_null() const override;
+    virtual bool is_valid() const override;
     virtual void set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const override;
     virtual void set_version(persistent::version_t ver) const override;
     virtual persistent::version_t get_version() const override;
@@ -171,9 +170,7 @@ public:
     std::string                                         key;                     // object_id
     Blob                                                blob;                    // the object data
 
-    bool operator==(const ObjectWithStringKey& other);
-
-    bool is_valid() const;
+    // bool operator==(const ObjectWithStringKey& other);
 
     // constructor 0 : copy constructor
     ObjectWithStringKey(const std::string& _key, 
@@ -212,6 +209,7 @@ public:
 
     virtual const std::string& get_key_ref() const override;
     virtual bool is_null() const override;
+    virtual bool is_valid() const override;
     virtual void set_previous_version(persistent::version_t, persistent::version_t perv_ver_by_key) const override;
     virtual void set_version(persistent::version_t ver) const override;
     virtual persistent::version_t get_version() const override;

--- a/include/cascade/object.hpp
+++ b/include/cascade/object.hpp
@@ -76,7 +76,7 @@ class ObjectWithUInt64Key : public mutils::ByteRepresentable,
 public:
     mutable std::tuple<persistent::version_t,uint64_t> ver; // object version
     uint64_t                                           key; // object_id
-    persistent::version_t                              previous_version_by_key; // previous version by key, INVALID_VERSION for the first value of the key.
+    mutable persistent::version_t                      previous_version_by_key; // previous version by key, INVALID_VERSION for the first value of the key.
     Blob                                               blob; // the object
 
     bool operator==(const ObjectWithUInt64Key& other);
@@ -118,7 +118,7 @@ public:
     // constructor 4 : default invalid constructor
     ObjectWithUInt64Key();
 
-    virtual void set_previous_version(persistent::version_t&, persistent::version_t& prev_ver_by_key) override;
+    virtual void set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const override;
 
     DEFAULT_SERIALIZATION_SUPPORT(ObjectWithUInt64Key, ver, key, previous_version_by_key, blob);
 
@@ -144,8 +144,10 @@ inline std::ostream& operator<<(std::ostream& out, const Blob& b) {
 
 inline std::ostream& operator<<(std::ostream& out, const ObjectWithUInt64Key& o) {
     out << "ObjectWithUInt64Key{ver: 0x" << std::hex << std::get<0>(o.ver) << std::dec 
-        << ", ts: " << std::get<1>(o.ver) << ", id:"
-        << o.key << ", data:" << o.blob << "}";
+        << ", ts: " << std::get<1>(o.ver) 
+        << ", prev_ver: " << std::hex << o.previous_version_by_key << std::dec
+        << ", id:" << o.key 
+        << ", data:" << o.blob << "}";
     return out;
 }
 
@@ -154,7 +156,7 @@ class ObjectWithStringKey : public mutils::ByteRepresentable,
 public:
     mutable std::tuple<persistent::version_t,uint64_t> ver;                     // object version
     std::string                                        key;                     // object_id
-    persistent::version_t                              previous_version_by_key; // previous version by key, INVALID_VERSION for the first value of the key.
+    mutable persistent::version_t                      previous_version_by_key; // previous version by key, INVALID_VERSION for the first value of the key.
     Blob                                               blob;                    // the object data
 
     bool operator==(const ObjectWithStringKey& other);
@@ -196,7 +198,7 @@ public:
     // constructor 4 : default invalid constructor
     ObjectWithStringKey();
 
-    virtual void set_previous_version(persistent::version_t&, persistent::version_t& perv_ver_by_key) override;
+    virtual void set_previous_version(persistent::version_t, persistent::version_t perv_ver_by_key)const override;
 
     DEFAULT_SERIALIZATION_SUPPORT(ObjectWithStringKey, ver, key, previous_version_by_key, blob);
 

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -172,7 +172,7 @@ const uint64_t& ObjectWithUInt64Key::get_key_ref() const {
 }
 
 bool ObjectWithUInt64Key::is_null() const {
-    return (this->blob.size > 0);
+    return (this->blob.size == 0);
 }
 
 void ObjectWithUInt64Key::set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const {
@@ -278,7 +278,7 @@ const std::string& ObjectWithStringKey::get_key_ref() const {
 }
 
 bool ObjectWithStringKey::is_null() const {
-    return (this->blob.size > 0);
+    return (this->blob.size == 0);
 }
 
 

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -171,6 +171,10 @@ const uint64_t& ObjectWithUInt64Key::get_key_ref() const {
     return this->key;
 }
 
+bool ObjectWithUInt64Key::is_null() const {
+    return (this->blob.size > 0);
+}
+
 void ObjectWithUInt64Key::set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const {
     this->previous_version_by_key = prev_ver_by_key;
 }
@@ -189,6 +193,11 @@ void ObjectWithUInt64Key::set_timestamp(uint64_t ts_us) const {
 
 uint64_t ObjectWithUInt64Key::get_timestamp() const {
     return this->timestamp_us;
+}
+
+template <>
+ObjectWithUInt64Key create_null_object_cb<uint64_t,ObjectWithUInt64Key,&ObjectWithUInt64Key::IK,&ObjectWithUInt64Key::IV>(const uint64_t& key) {
+    return ObjectWithUInt64Key(key,Blob{});
 }
 
 bool ObjectWithStringKey::operator==(const ObjectWithStringKey& other) {
@@ -268,6 +277,11 @@ const std::string& ObjectWithStringKey::get_key_ref() const {
     return this->key;
 }
 
+bool ObjectWithStringKey::is_null() const {
+    return (this->blob.size > 0);
+}
+
+
 void ObjectWithStringKey::set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const {
     this->previous_version_by_key = prev_ver_by_key;
 }
@@ -286,6 +300,11 @@ void ObjectWithStringKey::set_timestamp(uint64_t ts_us) const {
 
 uint64_t ObjectWithStringKey::get_timestamp() const {
     return this->timestamp_us;
+}
+
+template <>
+ObjectWithStringKey create_null_object_cb<std::string,ObjectWithStringKey,&ObjectWithStringKey::IK,&ObjectWithStringKey::IV>(const std::string& key) {
+    return ObjectWithStringKey(key,Blob{});
 }
 
 } // namespace cascade

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -102,29 +102,68 @@ bool ObjectWithUInt64Key::is_valid() const {
 }
 
 // constructor 0 : copy constructor
-ObjectWithUInt64Key::ObjectWithUInt64Key(const uint64_t& _key, const Blob& _blob) : ver(persistent::INVALID_VERSION,0),
-                                             key(_key),
-                                             blob(_blob) {}
+ObjectWithUInt64Key::ObjectWithUInt64Key(const uint64_t& _key,
+                                         const persistent::version_t& _previous_version_by_key,
+                                         const Blob& _blob) : 
+    ver(persistent::INVALID_VERSION,0),
+    key(_key),
+    previous_version_by_key(_previous_version_by_key),
+    blob(_blob) {}
+
 // constructor 0.5 : copy constructor
-ObjectWithUInt64Key::ObjectWithUInt64Key(const std::tuple<persistent::version_t,uint64_t> _ver, const uint64_t& _key, const Blob& _blob) : ver(_ver), key(_key), blob(_blob) {}
+ObjectWithUInt64Key::ObjectWithUInt64Key(const std::tuple<persistent::version_t,uint64_t> _ver,
+                                         const uint64_t& _key,
+                                         const persistent::version_t& _previous_version_by_key,
+                                         const Blob& _blob) :
+    ver(_ver),
+    key(_key), 
+    previous_version_by_key(_previous_version_by_key),
+    blob(_blob) {}
 
 // constructor 1 : copy consotructor
-ObjectWithUInt64Key::ObjectWithUInt64Key(const uint64_t _key, const char* const _b, const std::size_t _s) : ver(persistent::INVALID_VERSION,0),
-                                                                          key(_key),
-                                                                          blob(_b, _s) {}
+ObjectWithUInt64Key::ObjectWithUInt64Key(const uint64_t _key,
+                                         const persistent::version_t& _previous_version_by_key,
+                                         const char* const _b,
+                                         const std::size_t _s) :
+    ver(persistent::INVALID_VERSION,0),
+    key(_key),
+    previous_version_by_key(_previous_version_by_key),
+    blob(_b, _s) {}
+
 // constructor 1.5 : copy constructor
-ObjectWithUInt64Key::ObjectWithUInt64Key(const std::tuple<persistent::version_t,uint64_t> _ver, const uint64_t _key, const char* const _b, const std::size_t _s) : ver(_ver), key(_key), blob(_b, _s) {}
+ObjectWithUInt64Key::ObjectWithUInt64Key(const std::tuple<persistent::version_t,uint64_t> _ver,
+                                         const uint64_t _key,
+                                         const persistent::version_t& _previous_version_by_key,
+                                         const char* const _b,
+                                         const std::size_t _s) :
+    ver(_ver),
+    key(_key),
+    previous_version_by_key(_previous_version_by_key),
+    blob(_b, _s) {}
 
 // constructor 2 : move constructor
-ObjectWithUInt64Key::ObjectWithUInt64Key(ObjectWithUInt64Key&& other) : ver(other.ver),
-                         key(other.key),
-                         blob(std::move(other.blob)) {}
+ObjectWithUInt64Key::ObjectWithUInt64Key(ObjectWithUInt64Key&& other) :
+    ver(other.ver),
+    key(other.key),
+    previous_version_by_key(other.previous_version_by_key),
+    blob(std::move(other.blob)) {}
+
 // constructor 3 : copy constructor
-ObjectWithUInt64Key::ObjectWithUInt64Key(const ObjectWithUInt64Key& other) : ver(other.ver),
-                              key(other.key),
-                              blob(other.blob) {}
+ObjectWithUInt64Key::ObjectWithUInt64Key(const ObjectWithUInt64Key& other) :
+    ver(other.ver),
+    key(other.key),
+    previous_version_by_key(other.previous_version_by_key),
+    blob(other.blob) {}
+
 // constructor 4 : default invalid constructor
-ObjectWithUInt64Key::ObjectWithUInt64Key() : ver(persistent::INVALID_VERSION,0), key(INVALID_UINT64_OBJECT_KEY) {}
+ObjectWithUInt64Key::ObjectWithUInt64Key() :
+    ver(persistent::INVALID_VERSION,0),
+    key(INVALID_UINT64_OBJECT_KEY),
+    previous_version_by_key(persistent::INVALID_VERSION) {}
+
+void ObjectWithUInt64Key::set_previous_version(persistent::version_t&, persistent::version_t& prev_ver_by_key) {
+    this->previous_version_by_key = prev_ver_by_key;
+}
 
 bool ObjectWithStringKey::operator==(const ObjectWithStringKey& other) {
     return (this->key == other.key) && (this->ver == other.ver);
@@ -135,29 +174,66 @@ bool ObjectWithStringKey::is_valid() const {
 }
 
 // constructor 0 : copy constructor
-ObjectWithStringKey::ObjectWithStringKey(const std::string& _key, const Blob& _blob) : ver(persistent::INVALID_VERSION,0),
-                                             key(_key),
-                                             blob(_blob) {}
+ObjectWithStringKey::ObjectWithStringKey(const std::string& _key, 
+                                         const persistent::version_t& _previous_version_by_key,
+                                         const Blob& _blob) : 
+    ver(persistent::INVALID_VERSION,0),
+    key(_key),
+    previous_version_by_key(_previous_version_by_key),
+    blob(_blob) {}
 // constructor 0.5 : copy constructor
-ObjectWithStringKey::ObjectWithStringKey(const std::tuple<persistent::version_t,uint64_t> _ver, const std::string& _key, const Blob& _blob) : ver(_ver), key(_key), blob(_blob) {}
+ObjectWithStringKey::ObjectWithStringKey(const std::tuple<persistent::version_t,uint64_t> _ver,
+                                         const std::string& _key,
+                                         const persistent::version_t& _previous_version_by_key,
+                                         const Blob& _blob) :
+    ver(_ver),
+    key(_key), 
+    previous_version_by_key(_previous_version_by_key),
+    blob(_blob) {}
 
 // constructor 1 : copy consotructor
-ObjectWithStringKey::ObjectWithStringKey(const std::string& _key, const char* const _b, const std::size_t _s) : ver(persistent::INVALID_VERSION,0),
-                                                                          key(_key),
-                                                                          blob(_b, _s) {}
+ObjectWithStringKey::ObjectWithStringKey(const std::string& _key,
+                                         const persistent::version_t& _previous_version_by_key,
+                                         const char* const _b, 
+                                         const std::size_t _s) : 
+    ver(persistent::INVALID_VERSION,0),
+    key(_key),
+    previous_version_by_key(_previous_version_by_key),
+    blob(_b, _s) {}
 // constructor 1.5 : copy constructor
-ObjectWithStringKey::ObjectWithStringKey(const std::tuple<persistent::version_t,uint64_t> _ver, const std::string& _key, const char* const _b, const std::size_t _s) : ver(_ver), key(_key), blob(_b, _s) {}
+ObjectWithStringKey::ObjectWithStringKey(const std::tuple<persistent::version_t,uint64_t> _ver,
+                                         const std::string& _key,
+                                         const persistent::version_t& _previous_version_by_key,
+                                         const char* const _b,
+                                         const std::size_t _s) : 
+    ver(_ver),
+    key(_key),
+    previous_version_by_key(_previous_version_by_key),
+    blob(_b, _s) {}
 
 // constructor 2 : move constructor
-ObjectWithStringKey::ObjectWithStringKey(ObjectWithStringKey&& other) : ver(other.ver),
-                         key(other.key),
-                         blob(std::move(other.blob)) {}
+ObjectWithStringKey::ObjectWithStringKey(ObjectWithStringKey&& other) : 
+    ver(other.ver),
+    key(other.key),
+    previous_version_by_key(other.previous_version_by_key),
+    blob(std::move(other.blob)) {}
+
 // constructor 3 : copy constructor
-ObjectWithStringKey::ObjectWithStringKey(const ObjectWithStringKey& other) : ver(other.ver),
-                              key(other.key),
-                              blob(other.blob) {}
+ObjectWithStringKey::ObjectWithStringKey(const ObjectWithStringKey& other) : 
+    ver(other.ver),
+    key(other.key),
+    previous_version_by_key(other.previous_version_by_key),
+    blob(other.blob) {}
+
 // constructor 4 : default invalid constructor
-ObjectWithStringKey::ObjectWithStringKey() : ver(persistent::INVALID_VERSION,0), key() {}
+ObjectWithStringKey::ObjectWithStringKey() : 
+    ver(persistent::INVALID_VERSION,0),
+    key(),
+    previous_version_by_key(persistent::INVALID_VERSION) {}
+
+void ObjectWithStringKey::set_previous_version(persistent::version_t&, persistent::version_t& prev_ver_by_key) {
+    this->previous_version_by_key = prev_ver_by_key;
+}
 
 } // namespace cascade
 } // namespace derecho

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -92,7 +92,6 @@ std::unique_ptr<Blob> Blob::from_bytes(mutils::DeserializationManager*, const ch
     return std::make_unique<Blob>(v + sizeof(std::size_t), ((std::size_t*)(v))[0]);
 }
 
-
 bool ObjectWithUInt64Key::operator==(const ObjectWithUInt64Key& other) {
     return (this->key == other.key) && (this->ver == other.ver);
 }
@@ -161,7 +160,7 @@ ObjectWithUInt64Key::ObjectWithUInt64Key() :
     key(INVALID_UINT64_OBJECT_KEY),
     previous_version_by_key(persistent::INVALID_VERSION) {}
 
-void ObjectWithUInt64Key::set_previous_version(persistent::version_t&, persistent::version_t& prev_ver_by_key) {
+void ObjectWithUInt64Key::set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const {
     this->previous_version_by_key = prev_ver_by_key;
 }
 
@@ -231,7 +230,7 @@ ObjectWithStringKey::ObjectWithStringKey() :
     key(),
     previous_version_by_key(persistent::INVALID_VERSION) {}
 
-void ObjectWithStringKey::set_previous_version(persistent::version_t&, persistent::version_t& prev_ver_by_key) {
+void ObjectWithStringKey::set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const {
     this->previous_version_by_key = prev_ver_by_key;
 }
 

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -107,6 +107,7 @@ ObjectWithUInt64Key::ObjectWithUInt64Key(const uint64_t _key,
                                          const Blob& _blob) : 
     version(persistent::INVALID_VERSION),
     timestamp_us(0),
+    previous_version(INVALID_VERSION),
     previous_version_by_key(INVALID_VERSION),
     key(_key),
     blob(_blob) {}
@@ -114,11 +115,13 @@ ObjectWithUInt64Key::ObjectWithUInt64Key(const uint64_t _key,
 // constructor 0.5 : copy constructor
 ObjectWithUInt64Key::ObjectWithUInt64Key(const persistent::version_t _version,
                                          const uint64_t _timestamp_us,
+                                         const persistent::version_t _previous_version,
                                          const persistent::version_t _previous_version_by_key,
                                          const uint64_t _key,
                                          const Blob& _blob) :
     version(_version),
     timestamp_us(_timestamp_us),
+    previous_version(_previous_version),
     previous_version_by_key(_previous_version_by_key),
     key(_key), 
     blob(_blob) {}
@@ -129,6 +132,7 @@ ObjectWithUInt64Key::ObjectWithUInt64Key(const uint64_t _key,
                                          const std::size_t _s) :
     version(persistent::INVALID_VERSION),
     timestamp_us(0),
+    previous_version(INVALID_VERSION),
     previous_version_by_key(INVALID_VERSION),
     key(_key),
     blob(_b, _s) {}
@@ -136,12 +140,14 @@ ObjectWithUInt64Key::ObjectWithUInt64Key(const uint64_t _key,
 // constructor 1.5 : copy constructor
 ObjectWithUInt64Key::ObjectWithUInt64Key(const persistent::version_t _version,
                                          const uint64_t _timestamp_us,
+                                         const persistent::version_t _previous_version,
                                          const persistent::version_t _previous_version_by_key,
                                          const uint64_t _key,
                                          const char* const _b,
                                          const std::size_t _s) :
     version(_version),
     timestamp_us(_timestamp_us),
+    previous_version(_previous_version),
     previous_version_by_key(_previous_version_by_key),
     key(_key),
     blob(_b, _s) {}
@@ -150,6 +156,7 @@ ObjectWithUInt64Key::ObjectWithUInt64Key(const persistent::version_t _version,
 ObjectWithUInt64Key::ObjectWithUInt64Key(ObjectWithUInt64Key&& other) :
     version(other.version),
     timestamp_us(other.timestamp_us),
+    previous_version(other.previous_version),
     previous_version_by_key(other.previous_version_by_key),
     key(other.key),
     blob(std::move(other.blob)) {}
@@ -158,6 +165,7 @@ ObjectWithUInt64Key::ObjectWithUInt64Key(ObjectWithUInt64Key&& other) :
 ObjectWithUInt64Key::ObjectWithUInt64Key(const ObjectWithUInt64Key& other) :
     version(other.version),
     timestamp_us(other.timestamp_us),
+    previous_version(other.previous_version),
     previous_version_by_key(other.previous_version_by_key),
     key(other.key),
     blob(other.blob) {}
@@ -166,6 +174,7 @@ ObjectWithUInt64Key::ObjectWithUInt64Key(const ObjectWithUInt64Key& other) :
 ObjectWithUInt64Key::ObjectWithUInt64Key() :
     version(persistent::INVALID_VERSION),
     timestamp_us(0),
+    previous_version(INVALID_VERSION),
     previous_version_by_key(INVALID_VERSION),
     key(INVALID_UINT64_OBJECT_KEY) {}
 
@@ -177,7 +186,8 @@ bool ObjectWithUInt64Key::is_null() const {
     return (this->blob.size == 0);
 }
 
-void ObjectWithUInt64Key::set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const {
+void ObjectWithUInt64Key::set_previous_version(persistent::version_t prev_ver, persistent::version_t prev_ver_by_key) const {
+    this->previous_version = prev_ver;
     this->previous_version_by_key = prev_ver_by_key;
 }
 
@@ -217,17 +227,20 @@ ObjectWithStringKey::ObjectWithStringKey(const std::string& _key,
                                          const Blob& _blob) : 
     version(persistent::INVALID_VERSION),
     timestamp_us(0),
+    previous_version(INVALID_VERSION),
     previous_version_by_key(INVALID_VERSION),
     key(_key),
     blob(_blob) {}
 // constructor 0.5 : copy constructor
 ObjectWithStringKey::ObjectWithStringKey(const persistent::version_t _version,
                                          const uint64_t _timestamp_us,
+                                         const persistent::version_t _previous_version,
                                          const persistent::version_t _previous_version_by_key,
                                          const std::string& _key,
                                          const Blob& _blob) :
     version(_version),
     timestamp_us(_timestamp_us),
+    previous_version(_previous_version),
     previous_version_by_key(_previous_version_by_key),
     key(_key), 
     blob(_blob) {}
@@ -238,18 +251,21 @@ ObjectWithStringKey::ObjectWithStringKey(const std::string& _key,
                                          const std::size_t _s) : 
     version(persistent::INVALID_VERSION),
     timestamp_us(0),
+    previous_version(INVALID_VERSION),
     previous_version_by_key(INVALID_VERSION),
     key(_key),
     blob(_b, _s) {}
 // constructor 1.5 : copy constructor
 ObjectWithStringKey::ObjectWithStringKey(const persistent::version_t _version,
                                          const uint64_t _timestamp_us,
+                                         const persistent::version_t _previous_version,
                                          const persistent::version_t _previous_version_by_key,
                                          const std::string& _key,
                                          const char* const _b,
                                          const std::size_t _s) : 
     version(_version),
     timestamp_us(_timestamp_us),
+    previous_version(_previous_version),
     previous_version_by_key(_previous_version_by_key),
     key(_key), 
     blob(_b, _s) {}
@@ -258,6 +274,7 @@ ObjectWithStringKey::ObjectWithStringKey(const persistent::version_t _version,
 ObjectWithStringKey::ObjectWithStringKey(ObjectWithStringKey&& other) : 
     version(other.version),
     timestamp_us(other.timestamp_us),
+    previous_version(other.previous_version),
     previous_version_by_key(other.previous_version_by_key),
     key(other.key),
     blob(std::move(other.blob)) {}
@@ -266,6 +283,7 @@ ObjectWithStringKey::ObjectWithStringKey(ObjectWithStringKey&& other) :
 ObjectWithStringKey::ObjectWithStringKey(const ObjectWithStringKey& other) : 
     version(other.version),
     timestamp_us(other.timestamp_us),
+    previous_version(other.previous_version),
     previous_version_by_key(other.previous_version_by_key),
     key(other.key),
     blob(other.blob) {}
@@ -274,6 +292,7 @@ ObjectWithStringKey::ObjectWithStringKey(const ObjectWithStringKey& other) :
 ObjectWithStringKey::ObjectWithStringKey() : 
     version(persistent::INVALID_VERSION),
     timestamp_us(0),
+    previous_version(INVALID_VERSION),
     previous_version_by_key(INVALID_VERSION),
     key() {}
 
@@ -286,7 +305,8 @@ bool ObjectWithStringKey::is_null() const {
 }
 
 
-void ObjectWithStringKey::set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const {
+void ObjectWithStringKey::set_previous_version(persistent::version_t prev_ver, persistent::version_t prev_ver_by_key) const {
+    this->previous_version = prev_ver;
     this->previous_version_by_key = prev_ver_by_key;
 }
 

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -167,6 +167,10 @@ ObjectWithUInt64Key::ObjectWithUInt64Key() :
     previous_version_by_key(INVALID_VERSION),
     key(INVALID_UINT64_OBJECT_KEY) {}
 
+const uint64_t& ObjectWithUInt64Key::get_key_ref() const {
+    return this->key;
+}
+
 void ObjectWithUInt64Key::set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const {
     this->previous_version_by_key = prev_ver_by_key;
 }
@@ -259,6 +263,10 @@ ObjectWithStringKey::ObjectWithStringKey() :
     timestamp_us(0),
     previous_version_by_key(INVALID_VERSION),
     key() {}
+
+const std::string& ObjectWithStringKey::get_key_ref() const {
+    return this->key;
+}
 
 void ObjectWithStringKey::set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const {
     this->previous_version_by_key = prev_ver_by_key;

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -92,12 +92,14 @@ std::unique_ptr<Blob> Blob::from_bytes(mutils::DeserializationManager*, const ch
     return std::make_unique<Blob>(v + sizeof(std::size_t), ((std::size_t*)(v))[0]);
 }
 
+/*
 bool ObjectWithUInt64Key::operator==(const ObjectWithUInt64Key& other) {
     return (this->key == other.key) && (this->version == other.version);
 }
+*/
 
 bool ObjectWithUInt64Key::is_valid() const {
-    return (key == INVALID_UINT64_OBJECT_KEY);
+    return (key != INVALID_UINT64_OBJECT_KEY);
 }
 
 // constructor 0 : copy constructor
@@ -200,9 +202,11 @@ ObjectWithUInt64Key create_null_object_cb<uint64_t,ObjectWithUInt64Key,&ObjectWi
     return ObjectWithUInt64Key(key,Blob{});
 }
 
+/*
 bool ObjectWithStringKey::operator==(const ObjectWithStringKey& other) {
     return (this->key == other.key) && (this->version == other.version);
 }
+*/
 
 bool ObjectWithStringKey::is_valid() const {
     return !key.empty();

--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -93,7 +93,7 @@ std::unique_ptr<Blob> Blob::from_bytes(mutils::DeserializationManager*, const ch
 }
 
 bool ObjectWithUInt64Key::operator==(const ObjectWithUInt64Key& other) {
-    return (this->key == other.key) && (this->ver == other.ver);
+    return (this->key == other.key) && (this->version == other.version);
 }
 
 bool ObjectWithUInt64Key::is_valid() const {
@@ -101,71 +101,94 @@ bool ObjectWithUInt64Key::is_valid() const {
 }
 
 // constructor 0 : copy constructor
-ObjectWithUInt64Key::ObjectWithUInt64Key(const uint64_t& _key,
-                                         const persistent::version_t& _previous_version_by_key,
+ObjectWithUInt64Key::ObjectWithUInt64Key(const uint64_t _key,
                                          const Blob& _blob) : 
-    ver(persistent::INVALID_VERSION,0),
+    version(persistent::INVALID_VERSION),
+    timestamp_us(0),
+    previous_version_by_key(INVALID_VERSION),
     key(_key),
-    previous_version_by_key(_previous_version_by_key),
     blob(_blob) {}
 
 // constructor 0.5 : copy constructor
-ObjectWithUInt64Key::ObjectWithUInt64Key(const std::tuple<persistent::version_t,uint64_t> _ver,
-                                         const uint64_t& _key,
-                                         const persistent::version_t& _previous_version_by_key,
+ObjectWithUInt64Key::ObjectWithUInt64Key(const persistent::version_t _version,
+                                         const uint64_t _timestamp_us,
+                                         const persistent::version_t _previous_version_by_key,
+                                         const uint64_t _key,
                                          const Blob& _blob) :
-    ver(_ver),
-    key(_key), 
+    version(_version),
+    timestamp_us(_timestamp_us),
     previous_version_by_key(_previous_version_by_key),
+    key(_key), 
     blob(_blob) {}
 
 // constructor 1 : copy consotructor
 ObjectWithUInt64Key::ObjectWithUInt64Key(const uint64_t _key,
-                                         const persistent::version_t& _previous_version_by_key,
                                          const char* const _b,
                                          const std::size_t _s) :
-    ver(persistent::INVALID_VERSION,0),
+    version(persistent::INVALID_VERSION),
+    timestamp_us(0),
+    previous_version_by_key(INVALID_VERSION),
     key(_key),
-    previous_version_by_key(_previous_version_by_key),
     blob(_b, _s) {}
 
 // constructor 1.5 : copy constructor
-ObjectWithUInt64Key::ObjectWithUInt64Key(const std::tuple<persistent::version_t,uint64_t> _ver,
+ObjectWithUInt64Key::ObjectWithUInt64Key(const persistent::version_t _version,
+                                         const uint64_t _timestamp_us,
+                                         const persistent::version_t _previous_version_by_key,
                                          const uint64_t _key,
-                                         const persistent::version_t& _previous_version_by_key,
                                          const char* const _b,
                                          const std::size_t _s) :
-    ver(_ver),
-    key(_key),
+    version(_version),
+    timestamp_us(_timestamp_us),
     previous_version_by_key(_previous_version_by_key),
+    key(_key),
     blob(_b, _s) {}
 
 // constructor 2 : move constructor
 ObjectWithUInt64Key::ObjectWithUInt64Key(ObjectWithUInt64Key&& other) :
-    ver(other.ver),
-    key(other.key),
+    version(other.version),
+    timestamp_us(other.timestamp_us),
     previous_version_by_key(other.previous_version_by_key),
+    key(other.key),
     blob(std::move(other.blob)) {}
 
 // constructor 3 : copy constructor
 ObjectWithUInt64Key::ObjectWithUInt64Key(const ObjectWithUInt64Key& other) :
-    ver(other.ver),
-    key(other.key),
+    version(other.version),
+    timestamp_us(other.timestamp_us),
     previous_version_by_key(other.previous_version_by_key),
+    key(other.key),
     blob(other.blob) {}
 
 // constructor 4 : default invalid constructor
 ObjectWithUInt64Key::ObjectWithUInt64Key() :
-    ver(persistent::INVALID_VERSION,0),
-    key(INVALID_UINT64_OBJECT_KEY),
-    previous_version_by_key(persistent::INVALID_VERSION) {}
+    version(persistent::INVALID_VERSION),
+    timestamp_us(0),
+    previous_version_by_key(INVALID_VERSION),
+    key(INVALID_UINT64_OBJECT_KEY) {}
 
 void ObjectWithUInt64Key::set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const {
     this->previous_version_by_key = prev_ver_by_key;
 }
 
+void ObjectWithUInt64Key::set_version(persistent::version_t ver) const {
+    this->version = ver;
+}
+
+persistent::version_t ObjectWithUInt64Key::get_version() const {
+    return this->version;
+}
+
+void ObjectWithUInt64Key::set_timestamp(uint64_t ts_us) const {
+    this->timestamp_us = ts_us;
+}
+
+uint64_t ObjectWithUInt64Key::get_timestamp() const {
+    return this->timestamp_us;
+}
+
 bool ObjectWithStringKey::operator==(const ObjectWithStringKey& other) {
-    return (this->key == other.key) && (this->ver == other.ver);
+    return (this->key == other.key) && (this->version == other.version);
 }
 
 bool ObjectWithStringKey::is_valid() const {
@@ -174,64 +197,87 @@ bool ObjectWithStringKey::is_valid() const {
 
 // constructor 0 : copy constructor
 ObjectWithStringKey::ObjectWithStringKey(const std::string& _key, 
-                                         const persistent::version_t& _previous_version_by_key,
                                          const Blob& _blob) : 
-    ver(persistent::INVALID_VERSION,0),
+    version(persistent::INVALID_VERSION),
+    timestamp_us(0),
+    previous_version_by_key(INVALID_VERSION),
     key(_key),
-    previous_version_by_key(_previous_version_by_key),
     blob(_blob) {}
 // constructor 0.5 : copy constructor
-ObjectWithStringKey::ObjectWithStringKey(const std::tuple<persistent::version_t,uint64_t> _ver,
+ObjectWithStringKey::ObjectWithStringKey(const persistent::version_t _version,
+                                         const uint64_t _timestamp_us,
+                                         const persistent::version_t _previous_version_by_key,
                                          const std::string& _key,
-                                         const persistent::version_t& _previous_version_by_key,
                                          const Blob& _blob) :
-    ver(_ver),
-    key(_key), 
+    version(_version),
+    timestamp_us(_timestamp_us),
     previous_version_by_key(_previous_version_by_key),
+    key(_key), 
     blob(_blob) {}
 
 // constructor 1 : copy consotructor
 ObjectWithStringKey::ObjectWithStringKey(const std::string& _key,
-                                         const persistent::version_t& _previous_version_by_key,
                                          const char* const _b, 
                                          const std::size_t _s) : 
-    ver(persistent::INVALID_VERSION,0),
+    version(persistent::INVALID_VERSION),
+    timestamp_us(0),
+    previous_version_by_key(INVALID_VERSION),
     key(_key),
-    previous_version_by_key(_previous_version_by_key),
     blob(_b, _s) {}
 // constructor 1.5 : copy constructor
-ObjectWithStringKey::ObjectWithStringKey(const std::tuple<persistent::version_t,uint64_t> _ver,
+ObjectWithStringKey::ObjectWithStringKey(const persistent::version_t _version,
+                                         const uint64_t _timestamp_us,
+                                         const persistent::version_t _previous_version_by_key,
                                          const std::string& _key,
-                                         const persistent::version_t& _previous_version_by_key,
                                          const char* const _b,
                                          const std::size_t _s) : 
-    ver(_ver),
-    key(_key),
+    version(_version),
+    timestamp_us(_timestamp_us),
     previous_version_by_key(_previous_version_by_key),
+    key(_key), 
     blob(_b, _s) {}
 
 // constructor 2 : move constructor
 ObjectWithStringKey::ObjectWithStringKey(ObjectWithStringKey&& other) : 
-    ver(other.ver),
-    key(other.key),
+    version(other.version),
+    timestamp_us(other.timestamp_us),
     previous_version_by_key(other.previous_version_by_key),
+    key(other.key),
     blob(std::move(other.blob)) {}
 
 // constructor 3 : copy constructor
 ObjectWithStringKey::ObjectWithStringKey(const ObjectWithStringKey& other) : 
-    ver(other.ver),
-    key(other.key),
+    version(other.version),
+    timestamp_us(other.timestamp_us),
     previous_version_by_key(other.previous_version_by_key),
+    key(other.key),
     blob(other.blob) {}
 
 // constructor 4 : default invalid constructor
 ObjectWithStringKey::ObjectWithStringKey() : 
-    ver(persistent::INVALID_VERSION,0),
-    key(),
-    previous_version_by_key(persistent::INVALID_VERSION) {}
+    version(persistent::INVALID_VERSION),
+    timestamp_us(0),
+    previous_version_by_key(INVALID_VERSION),
+    key() {}
 
 void ObjectWithStringKey::set_previous_version(persistent::version_t, persistent::version_t prev_ver_by_key) const {
     this->previous_version_by_key = prev_ver_by_key;
+}
+
+void ObjectWithStringKey::set_version(persistent::version_t ver) const {
+    this->version = ver;
+}
+
+persistent::version_t ObjectWithStringKey::get_version() const {
+    return this->version;
+}
+
+void ObjectWithStringKey::set_timestamp(uint64_t ts_us) const {
+    this->timestamp_us = ts_us;
+}
+
+uint64_t ObjectWithStringKey::get_timestamp() const {
+    return this->timestamp_us;
 }
 
 } // namespace cascade

--- a/src/test/cli_example.cpp
+++ b/src/test/cli_example.cpp
@@ -63,7 +63,8 @@ static void client_put(derecho::ExternalGroup<VCS,PCS>& group,
 
     uint64_t key = std::stoll(tokens[1]);
     
-    ObjectWithUInt64Key o(key,Blob(tokens[2].c_str(),tokens[2].size()));
+    //TODO: the previous_version should be used to enforce version check. INVALID_VERSION disables the feature.
+    ObjectWithUInt64Key o(key,INVALID_VERSION,Blob(tokens[2].c_str(),tokens[2].size()));
 
     if (is_persistent) {
         ExternalClientCaller<PCS,std::remove_reference<decltype(group)>::type>& pcs_ec = group.get_subgroup_caller<PCS>();

--- a/src/test/cli_example.cpp
+++ b/src/test/cli_example.cpp
@@ -112,14 +112,14 @@ static void client_get(derecho::ExternalGroup<VCS,PCS>& group,
         if (ts != 0) {
             opt.emplace(pcs_ec.p2p_send<RPC_NAME(get_by_time)>(member,key,ts));
         } else {
-            opt.emplace(pcs_ec.p2p_send<RPC_NAME(get)>(member,key,ver));
+            opt.emplace(pcs_ec.p2p_send<RPC_NAME(get)>(member,key,ver,false));
         }
     } else {
         ExternalClientCaller<VCS,std::remove_reference<decltype(group)>::type>& vcs_ec = group.get_subgroup_caller<VCS>();
         if (ts != 0) {
             opt.emplace(vcs_ec.p2p_send<RPC_NAME(get_by_time)>(member,key,ts));
         } else {
-            opt.emplace(vcs_ec.p2p_send<RPC_NAME(get)>(member,key,ver));
+            opt.emplace(vcs_ec.p2p_send<RPC_NAME(get)>(member,key,ver,false));
         }
     }
     auto reply = opt.value().get().get(member);

--- a/src/test/cli_example.cpp
+++ b/src/test/cli_example.cpp
@@ -64,7 +64,7 @@ static void client_put(derecho::ExternalGroup<VCS,PCS>& group,
     uint64_t key = std::stoll(tokens[1]);
     
     //TODO: the previous_version should be used to enforce version check. INVALID_VERSION disables the feature.
-    ObjectWithUInt64Key o(key,INVALID_VERSION,Blob(tokens[2].c_str(),tokens[2].size()));
+    ObjectWithUInt64Key o(key,Blob(tokens[2].c_str(),tokens[2].size()));
 
     if (is_persistent) {
         ExternalClientCaller<PCS,std::remove_reference<decltype(group)>::type>& pcs_ec = group.get_subgroup_caller<PCS>();

--- a/src/test/perf.cpp
+++ b/src/test/perf.cpp
@@ -348,7 +348,7 @@ int do_client(int argc,char** args) {
         node_id_t server_id = members[my_node_id % members.size()];
 
         for(uint64_t i = 0; i < num_messages; i++) {
-            ObjectWithUInt64Key o(randomize_key(i)%max_distinct_objects,Blob(bbuf, msg_size));
+            ObjectWithUInt64Key o(randomize_key(i)%max_distinct_objects,INVALID_VERSION,Blob(bbuf, msg_size));
             cs.do_send(i,[&o,&pcs_ec,&server_id](){return std::move(pcs_ec.p2p_send<RPC_NAME(put)>(server_id,o));});
         }
         free(bbuf);
@@ -368,7 +368,7 @@ int do_client(int argc,char** args) {
         node_id_t server_id = members[my_node_id % members.size()];
 
         for(uint64_t i = 0; i < num_messages; i++) {
-            ObjectWithUInt64Key o(randomize_key(i)%max_distinct_objects,Blob(bbuf, msg_size));
+            ObjectWithUInt64Key o(randomize_key(i)%max_distinct_objects,INVALID_VERSION,Blob(bbuf, msg_size));
             cs.do_send(i,[&o,&vcs_ec,&server_id](){return std::move(vcs_ec.p2p_send<RPC_NAME(put)>(server_id,o));});
         }
         free(bbuf);

--- a/src/test/perf.cpp
+++ b/src/test/perf.cpp
@@ -348,7 +348,7 @@ int do_client(int argc,char** args) {
         node_id_t server_id = members[my_node_id % members.size()];
 
         for(uint64_t i = 0; i < num_messages; i++) {
-            ObjectWithUInt64Key o(randomize_key(i)%max_distinct_objects,INVALID_VERSION,Blob(bbuf, msg_size));
+            ObjectWithUInt64Key o(randomize_key(i)%max_distinct_objects,Blob(bbuf, msg_size));
             cs.do_send(i,[&o,&pcs_ec,&server_id](){return std::move(pcs_ec.p2p_send<RPC_NAME(put)>(server_id,o));});
         }
         free(bbuf);
@@ -368,7 +368,7 @@ int do_client(int argc,char** args) {
         node_id_t server_id = members[my_node_id % members.size()];
 
         for(uint64_t i = 0; i < num_messages; i++) {
-            ObjectWithUInt64Key o(randomize_key(i)%max_distinct_objects,INVALID_VERSION,Blob(bbuf, msg_size));
+            ObjectWithUInt64Key o(randomize_key(i)%max_distinct_objects,Blob(bbuf, msg_size));
             cs.do_send(i,[&o,&vcs_ec,&server_id](){return std::move(vcs_ec.p2p_send<RPC_NAME(put)>(server_id,o));});
         }
         free(bbuf);


### PR DESCRIPTION
New Feature:
- Introduced a previous version in Cascade Object as a back pointer to keep efficient track of its previous values.
- Introduced ICascadeObject, IKeepVersion, IKeepPreviousVersion, and IKeepTimestamp interfaces to manage the features.