### PR TITLE
add --no-check-certificate in download_cnn_model.sh

### DIFF
--- a/src/service/data_path_logic/download_cnn_classifier_models.sh
+++ b/src/service/data_path_logic/download_cnn_classifier_models.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 for name in flower pet
 do
-    wget -c https://derecho.cs.cornell.edu/files/${name}-model.tar.bz2
+    wget -c https://derecho.cs.cornell.edu/files/${name}-model.tar.bz2 --no-check-certificate
     tar -jxf ${name}-model.tar.bz2
     rm -f ${name}-model.tar.bz2
 done


### PR DESCRIPTION
When using the original script, wget fails with:
```
--2020-12-29 05:15:20--  https://derecho.cs.cornell.edu/files/flower-model.tar.bz2
Resolving derecho.cs.cornell.edu (derecho.cs.cornell.edu)... 128.253.49.36
Connecting to derecho.cs.cornell.edu (derecho.cs.cornell.edu)|128.253.49.36|:443... connected.
ERROR: cannot verify derecho.cs.cornell.edu's certificate, issued by ‘CN=InCommon RSA Server CA,OU=InCommon,O=Internet2,L=Ann Arbor,ST=MI,C=US’:
  Issued certificate has expired.
To connect to derecho.cs.cornell.edu insecurely, use `--no-check-certificate'.
```

So I add ` --no-check-certificate`, maybe fixing this tiny yet annoying stuff is helpful.