### PR TITLE
Update console_printer documentation for proper bash commands to set application up in custom project

### DIFF
--- a/src/applications/standalone/console_printer_udl/README.md
+++ b/src/applications/standalone/console_printer_udl/README.md
@@ -7,7 +7,7 @@ project-folder $ mkdir build && cd build
 project-folder/build $ cmake ../console_printer_udl/
 project-folder/build $ make
 ```
-Then you should see the udl binary `libconsole_printer_udl.so` in your build folder.
+Then you should see the udl binary `libconsole_printer_udl.so` in your `build` folder.
 
 To test, use the minimal configuration in the `cfg` folder. Please start three terminal consoles and change the current directory to `cfg/n0`, `cfg/n1`, and `cfg/n2`. We use folder `cfg/n0` and `cfg/n1` for the configuration for tow Cascade Server nodes; while `cfg/n2` is for the client node. In the server consoles, start the server as follows.
 ```

--- a/src/applications/standalone/console_printer_udl/README.md
+++ b/src/applications/standalone/console_printer_udl/README.md
@@ -3,7 +3,7 @@
 1. Copy the `console_printer_udl` folder to your own project.
 1. Build the project as follows:
 ```
-project-folder $ makedir build; cd build
+project-folder $ mkdir build && cd build
 project-folder/build $ make
 ```
 Then you should see the udl binary `libconsole_printer_udl.so` in your build folder.

--- a/src/applications/standalone/console_printer_udl/README.md
+++ b/src/applications/standalone/console_printer_udl/README.md
@@ -3,7 +3,8 @@
 1. Copy the `console_printer_udl` folder to your own project.
 1. Build the project as follows:
 ```
-project-folder $ mkdir build && cd build
+project-folder $ mkdir build && cd build 
+project-folder/build $ cmake ../console_printer_udl/
 project-folder/build $ make
 ```
 Then you should see the udl binary `libconsole_printer_udl.so` in your build folder.


### PR DESCRIPTION
The previous commands did not work when trying to set up Cascade in a personal project. Now, these updated commands successfully build Cascade. 