### PR TITLE
Cascade DDS server timestamp and bugfix in dds sample config file.

### DIFF
--- a/src/applications/standalone/dds/CMakeLists.txt
+++ b/src/applications/standalone/dds/CMakeLists.txt
@@ -21,6 +21,8 @@ set(UDL_UUID 94f8509c-a6e6-11ec-a9f5-0242ac110002)
 
 set(DISABLE_DDS_COPY 0)
 
+set(ENABLE_SERVER_TIMESTAMP_LOG 1)
+
 CONFIGURE_FILE(${CMAKE_CURRENT_SOURCE_DIR}/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/include/cascade_dds/config.h)
 
 add_library(cascade_dds SHARED src/dds.cpp)

--- a/src/applications/standalone/dds/cfg/dfgs.json
+++ b/src/applications/standalone/dds/cfg/dfgs.json
@@ -5,7 +5,7 @@
     "graph" : [
       {
         "pathname" : "/dds/tiny_text",
-        "shard_dispatcher_list" : "all",
+        "shard_dispatcher_list" : ["all"],
         "user_defined_logic_hook_list" : ["both"],
         "user_defined_logic_list" : ["94f8509c-a6e6-11ec-a9f5-0242ac110002"],
         "user_defined_logic_stateful_list" : ["stateful"],
@@ -14,7 +14,7 @@
       },
       {
         "pathname" : "/dds/big_chunk",
-        "shard_dispatcher_list" : "all",
+        "shard_dispatcher_list" : ["all"],
         "user_defined_logic_hook_list" : ["both"],
         "user_defined_logic_list" : ["94f8509c-a6e6-11ec-a9f5-0242ac110002"],
         "user_defined_logic_stateful_list" : ["stateful"],

--- a/src/applications/standalone/dds/cfg/dfgs.json
+++ b/src/applications/standalone/dds/cfg/dfgs.json
@@ -5,6 +5,7 @@
     "graph" : [
       {
         "pathname" : "/dds/tiny_text",
+        "shard_dispatcher_list" : "all",
         "user_defined_logic_hook_list" : ["both"],
         "user_defined_logic_list" : ["94f8509c-a6e6-11ec-a9f5-0242ac110002"],
         "user_defined_logic_stateful_list" : ["stateful"],
@@ -13,6 +14,7 @@
       },
       {
         "pathname" : "/dds/big_chunk",
+        "shard_dispatcher_list" : "all",
         "user_defined_logic_hook_list" : ["both"],
         "user_defined_logic_list" : ["94f8509c-a6e6-11ec-a9f5-0242ac110002"],
         "user_defined_logic_stateful_list" : ["stateful"],

--- a/src/applications/standalone/dds/config.h.in
+++ b/src/applications/standalone/dds/config.h.in
@@ -1,2 +1,3 @@
 #define UDL_UUID    "@UDL_UUID@"
 #define DISABLE_DDS_COPY    @DISABLE_DDS_COPY@
+#cmakedefine ENABLE_SERVER_TIMESTAMP_LOG

--- a/src/applications/standalone/dds/include/cascade_dds/dds.hpp
+++ b/src/applications/standalone/dds/include/cascade_dds/dds.hpp
@@ -178,8 +178,10 @@ public:
         INVALID_TYPE,
         SUBSCRIBE,
         UNSUBSCRIBE,
+#ifdef ENABLE_SERVER_TIMESTAMP_LOG
         FLUSH_TIMESTAMP_TRIGGER, // trigger a flush timestamp operation (in trigger)
         FLUSH_TIMESTAMP_ORDERED // really flush timestamp
+#endif
     };
     /* Command type */
     CommandType command_type;
@@ -200,12 +202,14 @@ public:
         case UNSUBSCRIBE:
             command_name = "unsubscribe";
             break;
+#ifdef ENABLE_SERVER_TIMESTAMP_LOG
         case FLUSH_TIMESTAMP_TRIGGER:
             command_name = "flush_timestamp_trigger";
             break;
         case FLUSH_TIMESTAMP_ORDERED:
             command_name = "flush_timestamp_ordered";
             break;
+#endif
         default:
             command_name = "invalid";
         }
@@ -260,7 +264,9 @@ private:
     ServiceClientAPI&                       capi;
     std::unique_ptr<DDSSubscriberRegistry>  subscriber_registry;
     std::unique_ptr<DDSMetadataClient>      metadata_service;
+#ifdef ENABLE_SERVER_TIMESTAMP_LOG
     std::string                             control_plane_suffix;
+#endif
 
 public:
     /**
@@ -298,11 +304,13 @@ public:
     template <typename MessageType>
     void unsubscribe(const std::unique_ptr<DDSSubscriber<MessageType>>& subscriber);
 
+#ifdef ENABLE_SERVER_TIMESTAMP_LOG
     /**
      * flush the timestamp of a topic
      * @param topic                 topic name
      */
     void flush_timestamp(const std::string& topic);
+#endif
 
     /**
      * destructor

--- a/src/applications/standalone/dds/include/cascade_dds/dds.hpp
+++ b/src/applications/standalone/dds/include/cascade_dds/dds.hpp
@@ -3,6 +3,7 @@
 #include <derecho/mutils-serialization/SerializationSupport.hpp>
 #include <memory>
 #include <mutex>
+#include <string>
 #include <vector>
 #include <unordered_map>
 #include <shared_mutex>
@@ -177,6 +178,8 @@ public:
         INVALID_TYPE,
         SUBSCRIBE,
         UNSUBSCRIBE,
+        FLUSH_TIMESTAMP_TRIGGER, // trigger a flush timestamp operation (in trigger)
+        FLUSH_TIMESTAMP_ORDERED // really flush timestamp
     };
     /* Command type */
     CommandType command_type;
@@ -196,6 +199,12 @@ public:
             break;
         case UNSUBSCRIBE:
             command_name = "unsubscribe";
+            break;
+        case FLUSH_TIMESTAMP_TRIGGER:
+            command_name = "flush_timestamp_trigger";
+            break;
+        case FLUSH_TIMESTAMP_ORDERED:
+            command_name = "flush_timestamp_ordered";
             break;
         default:
             command_name = "invalid";
@@ -251,6 +260,7 @@ private:
     ServiceClientAPI&                       capi;
     std::unique_ptr<DDSSubscriberRegistry>  subscriber_registry;
     std::unique_ptr<DDSMetadataClient>      metadata_service;
+    std::string                             control_plane_suffix;
 
 public:
     /**
@@ -287,6 +297,12 @@ public:
      */
     template <typename MessageType>
     void unsubscribe(const std::unique_ptr<DDSSubscriber<MessageType>>& subscriber);
+
+    /**
+     * flush the timestamp of a topic
+     * @param topic                 topic name
+     */
+    void flush_timestamp(const std::string& topic);
 
     /**
      * destructor

--- a/src/applications/standalone/dds/src/client.cpp
+++ b/src/applications/standalone/dds/src/client.cpp
@@ -545,6 +545,7 @@ std::vector<command_entry_t> commands = {
             return run_perftest(metadata_client,client,topic,pub_mode,count,rate_mps);
         }
     },
+#ifdef ENABLE_SERVER_TIMESTAMP_LOG
     {
         "flush_timestamp",
         "Flush and clear the timestamp logger for a topic",
@@ -556,6 +557,7 @@ std::vector<command_entry_t> commands = {
             return true;
         }
     },
+#endif
 };
 
 static void do_command(

--- a/src/applications/standalone/dds/src/client.cpp
+++ b/src/applications/standalone/dds/src/client.cpp
@@ -545,6 +545,17 @@ std::vector<command_entry_t> commands = {
             return run_perftest(metadata_client,client,topic,pub_mode,count,rate_mps);
         }
     },
+    {
+        "flush_timestamp",
+        "Flush and clear the timestamp logger for a topic",
+        "flush_timestamp <topic>",
+        [](DDSMetadataClient& metadata_client,DDSClient& client,const std::vector<std::string>& cmd_tokens) {
+            CHECK_FORMAT(cmd_tokens,1);
+            std::string topic = cmd_tokens[1];
+            client.flush_timestamp(topic);
+            return true;
+        }
+    },
 };
 
 static void do_command(

--- a/src/applications/standalone/dds/src/dds.cpp
+++ b/src/applications/standalone/dds/src/dds.cpp
@@ -292,12 +292,15 @@ void DDSSubscriberRegistry::_topic_control(ServiceClientAPI& capi, const Topic& 
 
 DDSClient::DDSClient(
         const std::shared_ptr<DDSConfig>& _dds_config):
+#ifdef ENABLE_SERVER_TIMESTAMP_LOG
         control_plane_suffix(_dds_config->get_control_plane_suffix()),
+#endif
         capi(ServiceClientAPI::get_service_client()) {
     subscriber_registry = std::make_unique<DDSSubscriberRegistry>(_dds_config->get_control_plane_suffix());
     metadata_service = std::make_unique<DDSMetadataClient>(_dds_config->get_metadata_pathname());
 }
 
+#ifdef ENABLE_SERVER_TIMESTAMP_LOG
 void DDSClient::flush_timestamp(const std::string& topic) {
     auto topic_info = metadata_service->get_topic(topic);
     DDSCommand command(DDSCommand::CommandType::FLUSH_TIMESTAMP_TRIGGER,topic_info.name);
@@ -308,6 +311,7 @@ void DDSClient::flush_timestamp(const std::string& topic) {
     capi.trigger_put(object);
     dbg_default_trace("Sent DDS command:{} to service, command key={}", command.to_string(), object.get_key_ref());
 }
+#endif
 
 DDSClient::~DDSClient() {
     // nothing to release manually

--- a/src/applications/standalone/dds/src/dds_udl.cpp
+++ b/src/applications/standalone/dds/src/dds_udl.cpp
@@ -126,7 +126,11 @@ class DDSOCDPO: public OffCriticalDataPathObserver {
                     typed_ctxt->get_service_client_ref().notify(object->blob,key_string.substr(0,prefix_length-1),client_id);
                 }
 #ifdef ENABLE_SERVER_TIMESTAMP_LOG
-                server_timestamp.at(key_without_prefix).emplace_back(get_time_us());
+                // topic(key_without_prefix) may not exists in server_timestamp map if 
+                // subscriber_registry[topic] is empty.
+                if (server_timestamp.find(key_without_prefix) != server_timestamp.cend()) {
+                    server_timestamp.at(key_without_prefix).emplace_back(get_time_us());
+                }
 #endif
             } else {
                 dbg_default_trace("Key:{} is not found in subscriber_registry.", key_without_prefix);

--- a/src/applications/standalone/dds/src/dds_udl.cpp
+++ b/src/applications/standalone/dds/src/dds_udl.cpp
@@ -106,7 +106,7 @@ class DDSOCDPO: public OffCriticalDataPathObserver {
                                     seqno ++;
                                 }
                             }
-                            server_timestamp.clear();
+                            server_timestamp.at(command.topic).clear();
                             outfile.close();
                             dbg_default_trace("flush timestamp for topic:{}",command.topic);
 #endif

--- a/src/applications/standalone/dds/src/dds_udl.cpp
+++ b/src/applications/standalone/dds/src/dds_udl.cpp
@@ -2,6 +2,7 @@
 #include <cascade_dds/config.h>
 #include <cascade_dds/dds.hpp>
 #include <iostream>
+#include <fstream>
 #include <memory>
 #include <shared_mutex>
 #include <unordered_map>
@@ -27,6 +28,11 @@ class DDSOCDPO: public OffCriticalDataPathObserver {
     std::string control_plane_suffix;
     /* subscriber registry */
     std::unordered_map<std::string,std::unordered_set<node_id_t>> subscriber_registry;
+#ifdef ENABLE_SERVER_TIMESTAMP_LOG
+#define INIT_TIMESTAMP_SLOTS    (262144)
+    /* log the server timestamp, they are grouped by topic name */
+    std::unordered_map<std::string,std::vector<uint64_t>> server_timestamp;
+#endif
     /* Is shared_mutex fast enough? */
     mutable std::shared_mutex subscriber_registry_mutex;
 
@@ -38,9 +44,7 @@ class DDSOCDPO: public OffCriticalDataPathObserver {
                               const std::unordered_map<std::string,bool>&, // output
                               ICascadeContext* ctxt,
                               uint32_t /*worker_id*/) override {
-#ifdef ENABLE_SERVER_TIMESTAMP_LOG
         auto* typed_ctxt = dynamic_cast<DefaultCascadeContextType*>(ctxt);
-#endif
         if (key_string.size() <= prefix_length) {
             dbg_default_warn("{}: skipping invalid key_string:{}.", __PRETTY_FUNCTION__, key_string);
             return;
@@ -62,6 +66,11 @@ class DDSOCDPO: public OffCriticalDataPathObserver {
                             std::unique_lock<std::shared_mutex> wlock(this->subscriber_registry_mutex);
                             if (subscriber_registry.find(command.topic) == subscriber_registry.end()) {
                                 subscriber_registry.emplace(command.topic,std::unordered_set<node_id_t>{});
+#ifdef ENABLE_SERVER_TIMESTAMP_LOG
+                                // only add log for new topic.
+                                server_timestamp.emplace(command.topic,std::vector<uint64_t>{});
+                                server_timestamp.at(command.topic).reserve(INIT_TIMESTAMP_SLOTS);
+#endif
                             }
                             subscriber_registry.at(command.topic).emplace(sender);
                             dbg_default_trace("Sender {} subscribes to topic:{}",sender,command.topic);
@@ -69,11 +78,16 @@ class DDSOCDPO: public OffCriticalDataPathObserver {
                             std::unique_lock<std::shared_mutex> wlock(this->subscriber_registry_mutex);
                             if (subscriber_registry.find(command.topic) != subscriber_registry.end()) {
                                 subscriber_registry.at(command.topic).erase(sender);
+#ifdef ENABLE_SERVER_TIMESTAMP_LOG
+                                // remove it if nobody is listening to this topic.
+                                if (subscriber_registry.at(command.topic).empty()) {
+                                    server_timestamp.erase(command.topic);
+                                }
+#endif
                             }
                             dbg_default_trace("Sender {} unsubscribed from topic:{}",sender,command.topic);
 #ifdef ENABLE_SERVER_TIMESTAMP_LOG
                         } else if (command.command_type == DDSCommand::FLUSH_TIMESTAMP_TRIGGER){
-                            std::cout << "node " << sender << " triggered flush timestamp for topic: " << command.topic << std::endl;
                             DDSCommand ordered_flush_command(DDSCommand::CommandType::FLUSH_TIMESTAMP_ORDERED,command.topic);
                             std::size_t buffer_size = mutils::bytes_size(ordered_flush_command);
                             uint8_t stack_buffer[buffer_size];
@@ -82,9 +96,19 @@ class DDSOCDPO: public OffCriticalDataPathObserver {
                             typed_ctxt->get_service_client_ref().put_and_forget(object);
                             dbg_default_trace("Sender {} triggered flush timestamp for topic:{}",sender,command.topic);
                         } else if (command.command_type == DDSCommand::FLUSH_TIMESTAMP_ORDERED){
-                            // TODO: flush it.
-                            std::cout << "Member " << sender << " asked to flush timestamp for topic: " << command.topic << std::endl;
-                            dbg_default_trace("Member {} asked to flush timestamp for topic:{}",sender,command.topic);
+                            auto outfile = std::ofstream(command.topic+".log");
+                            outfile << "# seqno timestamp(us)" << std::endl;
+                            if (server_timestamp.find(command.topic) != server_timestamp.cend())
+                            {
+                                uint64_t seqno = 0;
+                                for(auto& ts : server_timestamp.at(command.topic)) {
+                                    outfile << seqno << " " << ts << std::endl;
+                                    seqno ++;
+                                }
+                            }
+                            server_timestamp.clear();
+                            outfile.close();
+                            dbg_default_trace("flush timestamp for topic:{}",command.topic);
 #endif
                         } else {
                             dbg_default_warn("Unknown DDS command Received: type={},topic='{}'",
@@ -96,12 +120,14 @@ class DDSOCDPO: public OffCriticalDataPathObserver {
             std::shared_lock<std::shared_mutex> rlck(subscriber_registry_mutex);
             if (subscriber_registry.find(key_without_prefix) != subscriber_registry.cend()) {
                 dbg_default_trace("Key:{} is found in subscriber_registry.", key_without_prefix);
-                auto* typed_ctxt = dynamic_cast<DefaultCascadeContextType*>(ctxt);
                 for (const auto& client_id: subscriber_registry.at(key_without_prefix)) {
                     dbg_default_trace("Forward a message of {} bytes from topic '{}' to external client {}.",
                             object->blob.size, key_without_prefix, client_id);
                     typed_ctxt->get_service_client_ref().notify(object->blob,key_string.substr(0,prefix_length-1),client_id);
                 }
+#ifdef ENABLE_SERVER_TIMESTAMP_LOG
+                server_timestamp.at(key_without_prefix).emplace_back(get_time_us());
+#endif
             } else {
                 dbg_default_trace("Key:{} is not found in subscriber_registry.", key_without_prefix);
             }

--- a/src/applications/standalone/dds/src/dds_udl.cpp
+++ b/src/applications/standalone/dds/src/dds_udl.cpp
@@ -105,8 +105,8 @@ class DDSOCDPO: public OffCriticalDataPathObserver {
                                     outfile << seqno << " " << ts << std::endl;
                                     seqno ++;
                                 }
+                                server_timestamp.at(command.topic).clear();
                             }
-                            server_timestamp.at(command.topic).clear();
                             outfile.close();
                             dbg_default_trace("flush timestamp for topic:{}",command.topic);
 #endif


### PR DESCRIPTION
+ Timestamping the arrival of a message on DDS servers. This feature helps break down end-to-end latency.
+ Fixed a hidden bug in DDS's sample dfgs.json: the dds udl should always set shard_dispatcher_list to 'all'