### PR TITLE
Concurrent read bugfix

### DIFF
--- a/include/cascade/detail/volatile_store_impl.hpp
+++ b/include/cascade/detail/volatile_store_impl.hpp
@@ -135,10 +135,26 @@ const VT VolatileCascadeStore<KT, VT, IK, IV>::get(const KT& key, const persiste
 #else
 #error Lockless support is currently for GCC only
 #endif
-        if(this->kv_map.find(key) != this->kv_map.end()) {
-            copied_out.copy_from(this->kv_map.at(key));
-        } else {
-            copied_out.copy_from(*IV);
+        /* 
+         * An out_of_range exception can be thrown even if 'key' exists in
+         * kv_map. Since std::map is not thread-safe, and there is another
+         * thread modifying kv_map concurrently, the internal data structure can
+         * be changed while this thread is inside kv_map.at(key). Therefore, we
+         * keep trying until it is possible to copy either the object we are
+         * looking for, or the invalid object if it does not exist.
+         */
+        while(true) {
+            try {
+                if(this->kv_map.find(key) != this->kv_map.end()) {
+                    copied_out.copy_from(this->kv_map.at(key));
+                } else {
+                    copied_out.copy_from(*IV);
+                }
+
+                break;
+            } catch (const std::out_of_range&) {
+                dbg_default_debug("{}: out_of_range exception thrown while trying to get key {}", __PRETTY_FUNCTION__, key);
+            }
         }
         // compiler reordering barrier
 #ifdef __GNUC__

--- a/include/cascade/detail/volatile_store_impl.hpp
+++ b/include/cascade/detail/volatile_store_impl.hpp
@@ -141,7 +141,7 @@ const VT VolatileCascadeStore<KT, VT, IK, IV>::get(const KT& key, const persiste
          * thread modifying kv_map concurrently, the internal data structure can
          * be changed while this thread is inside kv_map.at(key). Therefore, we
          * keep trying until it is possible to copy either the object we are
-         * looking for, or the invalid object if it does not exist.
+         * looking for, or the invalid object.
          */
         while(true) {
             try {


### PR DESCRIPTION
Thiago fixed the concurrent access to the std::map in VolatileCascadeStore/PersistentCascadeStore. More details: our lockless design allows multiple threads to access the std::map concurrently. Only one of them is the writer the others are the readers. However, the reader accessing std::map that is being updated might receive an exception. That is harmless because the std::map is consistent after the update. The fix is to retry on the exception.