### PR TITLE
Fix create_object_pool C++ client for affinity set

### DIFF
--- a/src/service/client.cpp
+++ b/src/service/client.cpp
@@ -921,7 +921,7 @@ std::vector<command_entry_t> commands =
         "create_object_pool <path> <type> <subgroup_index> [affinity_set_regex]\n"
             "type := " SUBGROUP_TYPE_LIST,
         [](ServiceClientAPI& capi, const std::vector<std::string>& cmd_tokens) {
-            CHECK_FORMAT(cmd_tokens,4);
+            CHECK_FORMAT(cmd_tokens,5);
             std::string opath = cmd_tokens[1];
             uint32_t subgroup_index = static_cast<uint32_t>(std::stoi(cmd_tokens[3],nullptr,0));
             std::string affinity_set_regex;


### PR DESCRIPTION
# Summary

Before, we called `CHECK_FORMAT` checking the `cmd_tokens` to a maximum of 4 tokens. However, if a user supplies an affinity set regex string, this will be marked as invalid. This PR simply changes the maximum to 5 tokens.

This is a simple one line change.