### PR TITLE
Minor CMake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12.4)
+cmake_minimum_required(VERSION 3.15)
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 project(cascade CXX)

--- a/src/applications/tests/CMakeLists.txt
+++ b/src/applications/tests/CMakeLists.txt
@@ -1,8 +1,3 @@
-cmake_minimum_required(VERSION 3.12.4)
-set(CMAKE_DISABLE_SOURCE_CHANGES ON)
-set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
-project(cascade CXX)
-
 add_subdirectory(unit_tests)
 add_subdirectory(cascade_as_subgroup_classes)
 add_subdirectory(user_defined_logic)

--- a/src/applications/tests/cascade_as_subgroup_classes/CMakeLists.txt
+++ b/src/applications/tests/cascade_as_subgroup_classes/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.10.0)
-set(CMAKE_DISABLE_SOURCE_CHANGES ON)
-set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
-
 # example with command line interface
 add_executable(cli_example cli_example.cpp)
 target_include_directories(cli_example PRIVATE

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.10.0)
-set(CMAKE_DISABLE_SOURCE_CHANGES ON)
-set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
-
 # cascade object
 add_library(core OBJECT object.cpp)
 target_include_directories(core PRIVATE

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.10.0)
-set(CMAKE_DISABLE_SOURCE_CHANGES ON)
-set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
-
 set(UDL_SIGNATURE_HEADER ${CMAKE_BINARY_DIR}/include/cascade/detail/udl_signature.hpp)
 set(UDL_SIGNATURE_BOOTSTRAPPING_HEADER ${CMAKE_CURRENT_SOURCE_DIR}/bootstrapping_udl_signature.hpp)
 
@@ -29,10 +25,10 @@ add_custom_command(TARGET udl_signature POST_BUILD
     COMMAND ${CMAKE_NM} _dummy_ | grep cascade | grep get_description | awk '{print \"\#define GET_DESCRIPTION_SIG \\\"\" \$\$3 \"\\\"\"}' >>
     udl_signature.hpp
     COMMAND ${CMAKE_NM} _dummy_ | grep cascade | grep initialize      | awk '{print \"\#define INITIALIZE_SIG \\\"\" \$\$3 \"\\\"\"}' >>
-    udl_signature.hpp 
+    udl_signature.hpp
     COMMAND ${CMAKE_NM} _dummy_ | grep cascade | grep get_observer    | awk '{print \"\#define GET_OBSERVER_SIG \\\"\" \$\$3 \"\\\"\"}' >>
-    udl_signature.hpp 
-    COMMAND ${CMAKE_NM} _dummy_ | grep cascade | grep release         | awk '{print \"\#define RELEASE_SIG \\\"\" \$\$3 \"\\\"\"}' >> 
+    udl_signature.hpp
+    COMMAND ${CMAKE_NM} _dummy_ | grep cascade | grep release         | awk '{print \"\#define RELEASE_SIG \\\"\" \$\$3 \"\\\"\"}' >>
     udl_signature.hpp
     COMMAND ${CMAKE_COMMAND} -E remove ${CMAKE_BINARY_DIR}/include/cascade/detail/udl_signature.hpp
     COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_BINARY_DIR}/udl_signature.hpp ${CMAKE_BINARY_DIR}/include/cascade/detail/udl_signature.hpp

--- a/src/service/cs/CMakeLists.txt
+++ b/src/service/cs/CMakeLists.txt
@@ -1,9 +1,3 @@
-cmake_minimum_required(VERSION 3.10.0)
-
-set(CMAKE_DISABLE_SOURCE_CHANGES ON)
-set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
-
-
 find_program(DOTNET_CMD dotnet)
 
 if (DOTNET_CMD)
@@ -34,20 +28,20 @@ if (DOTNET_CMD)
 
         install(TARGETS external_client_cs RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
         install(TARGETS member_client_cs RUNTIME DESTINATION ${CMAKE_INSTALL_LIBDIR})
-        
+
         # Custom target will always cause its dependencies to be evaluated and is
         # run by default
         add_custom_target(cascade_client_cs_library ALL
             DEPENDS custom_output
         )
-        
+
         # custom_output will always be rebuilt because it depends on always_rebuild
         add_custom_command(
             OUTPUT custom_output
             COMMAND echo "Built C# Cascade client CLI."
             DEPENDS always_rebuild
         )
-        
+
         # Build the external client C# DLL.
         add_custom_command(TARGET external_client_cs POST_BUILD
             COMMAND dotnet build ${CMAKE_CURRENT_SOURCE_DIR}/CascadeClient.csproj -o ${CMAKE_CURRENT_BINARY_DIR} -p:DefineConstants=IS_EXTERNAL_CLIENT /property:AssemblyName=ExternalClientCS

--- a/src/service/fuse/CMakeLists.txt
+++ b/src/service/fuse/CMakeLists.txt
@@ -1,8 +1,3 @@
-cmake_minimum_required(VERSION 3.10.0)
-
-set(CMAKE_DISABLE_SOURCE_CHANGES ON)
-set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
-
 find_package(derecho CONFIG REQUIRED)
 
 if (${HAS_FUSE})
@@ -15,7 +10,7 @@ if (${HAS_FUSE})
     )
     target_link_libraries(fuse_client cascade readline fuse3)
     set_target_properties(fuse_client PROPERTIES OUTPUT_NAME cascade_fuse_client)
- 
+
     add_custom_command(TARGET fuse_client POST_BUILD
         	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/testfuse.py ${CMAKE_CURRENT_BINARY_DIR}/.
         	COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/util.py ${CMAKE_CURRENT_BINARY_DIR}/.

--- a/src/service/java/CMakeLists.txt
+++ b/src/service/java/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required (VERSION 3.10.0)
-
 find_package(Java QUIET)
 
 if (NOT Java_FOUND)

--- a/src/service/python/CMakeLists.txt
+++ b/src/service/python/CMakeLists.txt
@@ -1,8 +1,3 @@
-cmake_minimum_required(VERSION 3.10.0)
-
-set(CMAKE_DISABLE_SOURCE_CHANGES ON)
-set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
-
 find_package(pybind11 QUIET)
 
 if (pybind11_FOUND)

--- a/src/service/python/CMakeLists.txt
+++ b/src/service/python/CMakeLists.txt
@@ -1,6 +1,8 @@
+find_package(Python 3.6 COMPONENTS Interpreter Development QUIET)
 find_package(pybind11 QUIET)
 
 if (pybind11_FOUND)
+    message(NOTICE "Pybind11 found. Python client enabled.")
     # test if some python dependencies are included
     execute_process(COMMAND pip3 show build RESULT_VARIABLE HAS_PYTHON_BUILD OUTPUT_QUIET ERROR_QUIET)
     if(NOT ${HAS_PYTHON_BUILD} EQUAL 0)
@@ -30,11 +32,12 @@ if (pybind11_FOUND)
     target_link_libraries(external_client_py PUBLIC cascade)
     add_custom_command(TARGET external_client_py PRE_LINK
         COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/derecho ${CMAKE_CURRENT_BINARY_DIR}/derecho)
+    # Use the Python_EXECUTABLE variable defined by FindPython since some systems call it "python3" and some call it "python"
     add_custom_command(TARGET external_client_py POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${CMAKE_CURRENT_BINARY_DIR}/README.md
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/cascade_client.py ${CMAKE_CURRENT_BINARY_DIR}/cascade_client.py
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/cascade_perf.py ${CMAKE_CURRENT_BINARY_DIR}/cascade_perf.py
-        COMMAND python -m build
+        COMMAND ${Python_EXECUTABLE} -m build
         DEPENDS cascade_client.py cascade_perf.py
     )
     set_target_properties(external_client_py PROPERTIES
@@ -54,7 +57,7 @@ if (pybind11_FOUND)
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/README.md ${CMAKE_CURRENT_BINARY_DIR}/README.md
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/cascade_client.py ${CMAKE_CURRENT_BINARY_DIR}/cascade_client.py
         COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/cascade_perf.py ${CMAKE_CURRENT_BINARY_DIR}/cascade_perf.py
-        COMMAND python -m build
+        COMMAND ${Python_EXECUTABLE} -m build
         DEPENDS cascade_client.py cascade_perf.py
     )
     set_target_properties(member_client_py PROPERTIES
@@ -65,5 +68,7 @@ if (pybind11_FOUND)
             TYPE BIN
             PERMISSIONS OWNER_WRITE OWNER_READ GROUP_READ WORLD_READ OWNER_EXECUTE GROUP_EXECUTE WORLD_EXECUTE
     )
+else()
+    message(NOTICE "Pybind11 not found. Python client is disabled.")
 endif()
 

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -1,7 +1,3 @@
-cmake_minimum_required(VERSION 3.10.0)
-set(CMAKE_DISABLE_SOURCE_CHANGES ON)
-set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
-
 add_library(utils OBJECT utils.cpp)
 target_include_directories(utils PRIVATE
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>


### PR DESCRIPTION
I realized that some minor fixes I made to the CMakeLists build setup in my cascade_chain branch have nothing to do with CascadeChain and should probably be ported over to the main branch. These include:
* Removing redundant re-declarations of cmake_minimum_version in subdirectory CMakeLists files, so the version can be set in once place at the root CMakeLists (this is standard practice as far as I can determine)
* Increasing the root CMakeLists's minimum version to 3.15, which is the newest available in Ubuntu 18.04
* Making the CMakeLists for the Python client use the `${Python_EXECUTABLE}` variable instead of the command "python" so it doesn't fail on Ubuntu systems where there is no executable named "python" (just "python2" and "python3")