### PR TITLE
Updated CMakeLists, removed global include for Derecho

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,16 +29,9 @@ if ( NOT DEFINED CMAKE_INSTALL_INCLUDEDIR )
     set( CMAKE_INSTALL_INCLUDEDIR include )
 endif ( )
 
-# The mutils package exports its location information in the "old" way,
-# with INCLUDE_DIRS and LIBRARIES variables
-
-# mutils_FOUND
-# mutils_INCLUDE_DIRS
-# mutils_LIBRARIES
 find_package(mutils REQUIRED)
 if(mutils_FOUND)
     message(STATUS "Found mutils in ${mutils_INCLUDE_DIRS}")
-    include_directories(${mutils_INCLUDE_DIRS})
 endif()
 
 # Cascade includes a custom Find module for GNU Readline (required by client.cpp)
@@ -53,19 +46,8 @@ find_package(OpenSSL REQUIRED)
 # derecho
 find_package(derecho CONFIG REQUIRED)
 
-# Derecho exports an IMPORT target, following the "new" way of
-# doing things, but for some reason we still need to do this
-# in order for some of the sub-components of Cascade to compile.
-# Ideally, if every target that needs the Derecho headers declares
-# its dependency on the IMPORT target derecho::derecho (i.e. with
-# target_link_libraries), they will each automatically include the
-# Derecho headers from the location specified by that target
-if(derecho_FOUND)
-    include_directories(${derecho_INCLUDE_DIRS})
-endif()
-
 # json
-find_package(nlohmann_json 3.2.0 REQUIRED)
+find_package(nlohmann_json 3.9.1 REQUIRED)
 
 # Hyperscan, which isn't packaged correctly and needs a custom Find module
 find_package(Hyperscan REQUIRED)
@@ -115,9 +97,9 @@ add_library(cascade SHARED
 #    $<TARGET_OBJECTS:utils>)
 
 target_link_libraries(cascade
-    derecho
+    derecho::derecho
     spdlog::spdlog
-    ${mutils_LIBRARIES}
+    mutils::mutils
     OpenSSL::Crypto
     ${Hyperscan_LIBRARIES})
 set_target_properties(cascade PROPERTIES
@@ -141,25 +123,21 @@ install(DIRECTORY
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
-    "${CMAKE_CURRENT_BINARY_DIR}/cascade/cascadeConfigVersion.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/cascadeConfigVersion.cmake"
     VERSION ${cascade_VERSION}
     COMPATIBILITY AnyNewerVersion
 )
 
 export (EXPORT cascadeTargets
-    FILE "${CMAKE_CURRENT_BINARY_DIR}/cascade/cascadeTargets.cmake"
+    FILE "${CMAKE_CURRENT_BINARY_DIR}/cmake/cascadeTargets.cmake"
 )
-
-#configure_file (cascadeConfig.cmake
-#    "${CMAKE_CURRENT_BINARY_DIR}/cascade/cascadeConfig.cmake"
-#)
 
 set(ConfigPackageLocation ${CMAKE_INSTALL_LIBDIR}/cmake/cascade)
 
 configure_package_config_file(cascadeConfig.cmake.in
-    "${CMAKE_CURRENT_BINARY_DIR}/cascade/cascadeConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/cascadeConfig.cmake"
     INSTALL_DESTINATION ${ConfigPackageLocation}
-    PATH_VARS CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_INCLUDEDIR ConfigPackageLocation
+    PATH_VARS CMAKE_INSTALL_LIBDIR CMAKE_INSTALL_INCLUDEDIR
 )
 
 install(EXPORT cascadeTargets
@@ -169,8 +147,8 @@ install(EXPORT cascadeTargets
 )
 
 install(FILES
-    "${CMAKE_CURRENT_BINARY_DIR}/cascade/cascadeConfig.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/cascade/cascadeConfigVersion.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/cascadeConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake/cascadeConfigVersion.cmake"
     DESTINATION ${ConfigPackageLocation}
 )
 

--- a/cascadeConfig.cmake.in
+++ b/cascadeConfig.cmake.in
@@ -1,7 +1,13 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+find_dependency(derecho)
+find_dependency(spdlog 1.3.1)
+find_dependency(OpenSSL)
+find_dependency(nlohmann_json 3.9.1)
+
 set_and_check(cascade_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
 set(cascade_LIBRARIES "-L@PACKAGE_CMAKE_INSTALL_LIBDIR@ -lcascade")
-include("@PACKAGE_ConfigPackageLocation@/cascadeTargets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/cascadeTargets.cmake")
 
 check_required_components(cascade)

--- a/src/applications/tests/pipeline/CMakeLists.txt
+++ b/src/applications/tests/pipeline/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(pipeline_udl PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
 )
-add_dependencies(pipeline_udl cascade)
+target_link_libraries(pipeline_udl cascade)
 add_custom_command(TARGET pipeline_udl POST_BUILD
      COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/trigger_put_pipeline_cfg
      ${CMAKE_CURRENT_BINARY_DIR}/trigger_put_pipeline_cfg

--- a/src/applications/tests/user_defined_logic/CMakeLists.txt
+++ b/src/applications/tests/user_defined_logic/CMakeLists.txt
@@ -9,7 +9,7 @@ target_include_directories(console_printer_udl PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
 )
-add_dependencies(console_printer_udl cascade)
+target_link_libraries(console_printer_udl cascade)
 add_custom_command(TARGET console_printer_udl POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/console_printer_cfg
     ${CMAKE_CURRENT_BINARY_DIR}/console_printer_cfg

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -7,3 +7,4 @@ target_include_directories(core PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_DIR}>
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
 )
+target_link_libraries(core derecho::derecho)

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -13,6 +13,7 @@ target_include_directories(udl_signature PRIVATE
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
+target_link_libraries(udl_signature derecho::derecho)
 set_target_properties(udl_signature PROPERTIES
     PREFIX  _
     OUTPUT_NAME dummy
@@ -40,6 +41,7 @@ target_include_directories(service PRIVATE
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
+target_link_libraries(service derecho::derecho)
 add_dependencies(service udl_signature)
 
 add_executable(server server.cpp)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -4,3 +4,4 @@ target_include_directories(utils PRIVATE
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_DIR}>
 )
+target_link_libraries(utils derecho::derecho)


### PR DESCRIPTION
Now that mutils has "modern" CMake packaging (see mpmilano/mutils#4) and Derecho properly forwards its package dependencies (see Derecho-Project/derecho#255), we can modernize the way Cascade depends on them. Besides depending on the mutils::mutils target (rather than `${mutils_LIBRARIES}`), we can also finally get rid of the global `include_directories(${derecho_INCLUDE_DIRS})` in favor of making each target within Cascade declare a link dependency on the derecho::derecho target.

Also, I discovered while fixing Derecho's CMake packaging that the Config.cmake file needs to have find_dependency() calls for each CMake package the project depends on, so I added those incantations to cascadeConfig.cmake.