### PR TITLE
New perftest modules for get()s

### DIFF
--- a/include/cascade/detail/debug_util.hpp
+++ b/include/cascade/detail/debug_util.hpp
@@ -45,12 +45,12 @@ struct TestVTConstructor {
 };
 
 template <typename KT, typename VT>
-void make_workload(uint32_t payload_size, const KT& key_prefix, std::vector<VT>& objects) {
+void make_workload(uint32_t payload_size, uint32_t num_distinct_objects, const KT& key_prefix, std::vector<VT>& objects) {
     if constexpr(TestVTConstructor<KT, VT>::value) {
         const uint32_t buf_size = payload_size - 128 - sizeof(key_prefix);
         uint8_t* buf = (uint8_t*)malloc(buf_size);
         memset(buf, 'A', buf_size);
-        for(uint32_t i = 0; i < NUMBER_OF_DISTINCT_OBJECTS; i++) {
+        for(uint32_t i = 0; i < num_distinct_objects; i++) {
             if constexpr(std::is_convertible_v<KT, std::string>) {
                 objects.emplace_back(key_prefix + std::to_string(i), buf, buf_size);
             } else if constexpr(std::is_integral_v<KT>) {

--- a/include/cascade/detail/debug_util.hpp
+++ b/include/cascade/detail/debug_util.hpp
@@ -27,7 +27,6 @@ template <typename KeyType>
 inline std::string get_pathname(const KeyType& key);
 
 #ifdef ENABLE_EVALUATION
-#define NUMBER_OF_DISTINCT_OBJECTS (4096)
 
 /**
  * This is a hidden API.

--- a/include/cascade/detail/persistent_store_impl.hpp
+++ b/include/cascade/detail/persistent_store_impl.hpp
@@ -201,6 +201,7 @@ const VT PersistentCascadeStore<KT, VT, IK, IV, ST>::get_by_time(const KT& key, 
 
     // get_global_stability_frontier return nano seconds.
     if(ts_us > subgroup_handle.compute_global_stability_frontier() / 1000) {
+        dbg_default_debug("Stability frontier is {} but requested timestamp is {}", subgroup_handle.compute_global_stability_frontier() / 1000, ts_us);
         dbg_default_warn("Cannot get data at a time in the future.");
         return *IV;
     }

--- a/src/service/client.cpp
+++ b/src/service/client.cpp
@@ -673,6 +673,40 @@ bool perftest(PerfTestClient& ptc,
     return ret;
 }
 
+// The object pool version of get perf test
+template <typename SubgroupType>
+bool perftest_get(PerfTestClient& ptc,
+                  const std::string& object_pool_pathname,
+                  ExternalClientToCascadeServerMapping ec2cs,
+                  uint64_t log_depth,
+                  uint64_t ops_threshold,
+                  uint64_t duration_secs,
+                  const std::string& output_filename) {
+    debug_enter_func_with_args("object_pool_pathname={},ec2cs={},log_depth={},ops_threshold={},duration_secs={},output_filename={}",
+                               object_pool_pathname, static_cast<uint32_t>(ec2cs), log_depth, ops_threshold, duration_secs, output_filename);
+    bool ret = ptc.template perf_get<SubgroupType>(object_pool_pathname, ec2cs, log_depth, ops_threshold, duration_secs, output_filename);
+    debug_leave_func();
+    return ret;
+}
+
+// The raw shard version of get perf test
+template <typename SubgroupType>
+bool perftest_get(PerfTestClient& ptc,
+                  uint32_t subgroup_index,
+                  uint32_t shard_index,
+                  ExternalClientToCascadeServerMapping ec2cs,
+                  uint64_t log_depth,
+                  uint64_t ops_threshold,
+                  uint64_t duration_secs,
+                  const std::string& output_filename) {
+    debug_enter_func_with_args("subgroup_index={},shard_index={},ec2cs={},log_depth={},ops_threshold={},duration_secs={},output_filename={}",
+                               subgroup_index, shard_index, static_cast<uint32_t>(ec2cs), log_depth, ops_threshold, duration_secs, output_filename);
+    bool ret = ptc.template perf_get<SubgroupType>(subgroup_index, shard_index, ec2cs, log_depth, ops_threshold, duration_secs, output_filename);
+    debug_leave_func();
+    return ret;
+}
+
+
 template <typename SubgroupType>
 bool perftest_ordered_put(ServiceClientAPI &capi,
                           uint32_t message_size,
@@ -1603,6 +1637,47 @@ std::vector<command_entry_t> commands =
         }
     },
     {
+        "perftest_op_get",
+        "Performance tester for get from an object pool.",
+        "perftest_op_get <type> <object pool pathname> <member selection policy> <log depth> <max rate> <duration> <client1> \n"
+            "type := " SUBGROUP_TYPE_LIST "\n"
+            "'member selection policy' refers how the external clients pick a member in a shard;\n"
+            "    Available options: FIXED|RANDOM|ROUNDROBIN;\n"
+            "'log depth' is the number of versions prior to the current version each get should request, 0 means to request the current version \n"
+            "'max rate' is the maximum number of operations in Operations per Second, 0 for best effort; \n"
+            "'duration' is the span of the whole experiment in seconds; \n"
+            "'client1' is a host[:port] pair representing the client. Currently only one client is supported. The port defaults to " + std::to_string(PERFTEST_PORT),
+        [](ServiceClientAPI& capi, const std::vector<std::string>& cmd_tokens){
+            CHECK_FORMAT(cmd_tokens, 9);
+            std::string object_pool_pathname = cmd_tokens[2];
+            ExternalClientToCascadeServerMapping member_selection_policy = FIXED;
+            if (cmd_tokens[3] == "RANDOM") {
+                member_selection_policy = ExternalClientToCascadeServerMapping::RANDOM;
+            } else if (cmd_tokens[3] == "ROUNDROBIN") {
+                member_selection_policy = ExternalClientToCascadeServerMapping::ROUNDROBIN;
+            }
+            uint64_t log_depth = std::stoul(cmd_tokens[4], nullptr, 0);
+            uint64_t max_rate = std::stoul(cmd_tokens[5], nullptr, 0);
+            uint64_t duration_sec = std::stoul(cmd_tokens[6], nullptr, 0);
+
+            PerfTestClient ptc{capi};
+            uint32_t pos = 7;
+            while (pos < cmd_tokens.size()) {
+                std::string::size_type colon_pos = cmd_tokens[pos].find(':');
+                if (colon_pos == std::string::npos) {
+                    ptc.add_or_update_server(cmd_tokens[pos], PERFTEST_PORT);
+                } else {
+                    ptc.add_or_update_server(cmd_tokens[pos].substr(0, colon_pos),
+                                             static_cast<uint16_t>(std::stoul(cmd_tokens[pos].substr(colon_pos+1),nullptr,0)));
+                }
+                pos++;
+            }
+            bool ret = false;
+            on_subgroup_type(cmd_tokens[1], ret = perftest_get, ptc, object_pool_pathname, member_selection_policy, log_depth, max_rate, duration_sec, "timestamp.log");
+            return ret;
+        }
+    },
+    {
         "perftest_shard",
         "Performance Tester for put to a shard.",
         "perftest_shard <type> <put type> <subgroup index> <shard index> <member selection policy> <r/w ratio> <max rate> <duration in sec> <client1> [<client2>, ...] \n"
@@ -1652,6 +1727,50 @@ std::vector<command_entry_t> commands =
             }
             bool ret = false;
             on_subgroup_type(cmd_tokens[1], ret = perftest,ptc,put_type,subgroup_index,shard_index,member_selection_policy,read_write_ratio,max_rate,duration_sec,"output.log");
+            return ret;
+        }
+    },
+    {
+        "perftest_shard_get",
+        "Performance tester for get from a shard.",
+        "perfest_shard_get <type> <subgroup index> <shard index> <member selection policy> <log depth> <max rate> <duration> <client1>"
+            "type := " SUBGROUP_TYPE_LIST "\n"
+            "'member selection policy' refers how the external clients pick a member in a shard;\n"
+            "    Available options: FIXED|RANDOM|ROUNDROBIN;\n"
+            "'log depth' is the number of versions prior to the current version each get should request, 0 means to request the current version \n"
+            "'max rate' is the maximum number of operations in Operations per Second, 0 for best effort; \n"
+            "'duration' is the span of the whole experiment in seconds; \n"
+            "'client1' is a host[:port] pair representing the client. Currently only one client is supported. The port defaults to " + std::to_string(PERFTEST_PORT),
+        [](ServiceClientAPI& capi, const std::vector<std::string>& cmd_tokens) {
+            CHECK_FORMAT(cmd_tokens, 9);
+
+            uint32_t subgroup_index = std::stoul(cmd_tokens[2], nullptr, 0);
+            uint32_t shard_index = std::stoul(cmd_tokens[3], nullptr, 0);
+
+            ExternalClientToCascadeServerMapping member_selection_policy = FIXED;
+            if (cmd_tokens[4] == "RANDOM") {
+                member_selection_policy = ExternalClientToCascadeServerMapping::RANDOM;
+            } else if (cmd_tokens[4] == "ROUNDROBIN") {
+                member_selection_policy = ExternalClientToCascadeServerMapping::ROUNDROBIN;
+            }
+            uint64_t log_depth = std::stoul(cmd_tokens[5], nullptr, 0);
+            uint64_t max_rate = std::stoul(cmd_tokens[6], nullptr, 0);
+            uint64_t duration_sec = std::stoul(cmd_tokens[7], nullptr, 0);
+
+            PerfTestClient ptc{capi};
+            uint32_t pos = 8;
+            while (pos < cmd_tokens.size()) {
+                std::string::size_type colon_pos = cmd_tokens[pos].find(':');
+                if (colon_pos == std::string::npos) {
+                    ptc.add_or_update_server(cmd_tokens[pos], PERFTEST_PORT);
+                } else {
+                    ptc.add_or_update_server(cmd_tokens[pos].substr(0, colon_pos),
+                                             static_cast<uint16_t>(std::stoul(cmd_tokens[pos].substr(colon_pos+1),nullptr,0)));
+                }
+                pos++;
+            }
+            bool ret = false;
+            on_subgroup_type(cmd_tokens[1], ret = perftest_get, ptc, subgroup_index, shard_index, member_selection_policy, log_depth, max_rate, duration_sec, "timestamp.log");
             return ret;
         }
     },

--- a/src/service/client.cpp
+++ b/src/service/client.cpp
@@ -706,6 +706,22 @@ bool perftest_get(PerfTestClient& ptc,
     return ret;
 }
 
+// Object pool version of get_by_time perf test
+// Can only run on PersistentCascadeStore, so no template parameter
+bool perftest_get_by_time(PerfTestClient& ptc,
+                          const std::string& object_pool_pathname,
+                          ExternalClientToCascadeServerMapping ec2cs,
+                          uint64_t ms_in_past,
+                          uint64_t ops_threshold,
+                          uint64_t duration_secs,
+                          const std::string& output_filename) {
+    debug_enter_func_with_args("object_pool_pathname={},ec2cs={},ms_in_past={},ops_threshold={},duration_secs={},output_filename={}",
+                               object_pool_pathname, static_cast<uint32_t>(ec2cs), ms_in_past, ops_threshold, duration_secs, output_filename);
+    bool ret = ptc.perf_get_by_time<PersistentCascadeStoreWithStringKey>(object_pool_pathname, ec2cs, ms_in_past, ops_threshold, duration_secs, output_filename);
+    debug_leave_func();
+    return ret;
+}
+
 // Raw shard version of get_by_time perf test
 // Can only run on PersistentCascadeStore, so no template parameter
 bool perftest_get_by_time(PerfTestClient& ptc,
@@ -718,7 +734,7 @@ bool perftest_get_by_time(PerfTestClient& ptc,
                           const std::string& output_filename) {
     debug_enter_func_with_args("subgroup_index={},shard_index={},ec2cs={},ms_in_past={},ops_threshold={},duration_secs={},output_filename={}",
                                subgroup_index, shard_index, static_cast<uint32_t>(ec2cs), ms_in_past, ops_threshold, duration_secs, output_filename);
-    bool ret = ptc.template perf_get_by_time<PersistentCascadeStoreWithStringKey>(subgroup_index, shard_index, ec2cs, ms_in_past, ops_threshold, duration_secs, output_filename);
+    bool ret = ptc.perf_get_by_time<PersistentCascadeStoreWithStringKey>(subgroup_index, shard_index, ec2cs, ms_in_past, ops_threshold, duration_secs, output_filename);
     debug_leave_func();
     return ret;
 }
@@ -1690,6 +1706,52 @@ std::vector<command_entry_t> commands =
             }
             bool ret = false;
             on_subgroup_type(cmd_tokens[1], ret = perftest_get, ptc, object_pool_pathname, member_selection_policy, log_depth, max_rate, duration_sec, "timestamp.log");
+            return ret;
+        }
+    },
+    {
+        "perftest_op_get_by_time",
+        "Performance tester for get_by_time from an object pool.",
+        "perftest_op_get <type> <object pool pathname> <member selection policy> <time in past> <max rate> <duration> <client1> \n"
+            "type: must be PCSS because get_by_time is not supported for any other subgroup type \n"
+            "'member selection policy' refers how the external clients pick a member in a shard;\n"
+            "    Available options: FIXED|RANDOM|ROUNDROBIN;\n"
+            "'time in past' is the number of milliseconds prior to the start of the experiment that each get_by_time should request \n"
+            "'max rate' is the maximum number of operations in Operations per Second, 0 for best effort; \n"
+            "'duration' is the span of the whole experiment in seconds; \n"
+            "'client1' is a host[:port] pair representing the client. Currently only one client is supported. The port defaults to " + std::to_string(PERFTEST_PORT),
+        [](ServiceClientAPI& capi, const std::vector<std::string>& cmd_tokens){
+            CHECK_FORMAT(cmd_tokens, 9);
+            if(cmd_tokens[1] != "PCSS") {
+                print_red("Invalid subgroup type. Only Persistent Cascade Store supports get_by_time.");
+                return false;
+            }
+
+            std::string object_pool_pathname = cmd_tokens[2];
+            ExternalClientToCascadeServerMapping member_selection_policy = FIXED;
+            if (cmd_tokens[3] == "RANDOM") {
+                member_selection_policy = ExternalClientToCascadeServerMapping::RANDOM;
+            } else if (cmd_tokens[3] == "ROUNDROBIN") {
+                member_selection_policy = ExternalClientToCascadeServerMapping::ROUNDROBIN;
+            }
+            uint64_t ms_in_past = std::stoul(cmd_tokens[4], nullptr, 0);
+            uint64_t max_rate = std::stoul(cmd_tokens[5], nullptr, 0);
+            uint64_t duration_sec = std::stoul(cmd_tokens[6], nullptr, 0);
+
+            PerfTestClient ptc{capi};
+            uint32_t pos = 7;
+            while (pos < cmd_tokens.size()) {
+                std::string::size_type colon_pos = cmd_tokens[pos].find(':');
+                if (colon_pos == std::string::npos) {
+                    ptc.add_or_update_server(cmd_tokens[pos], PERFTEST_PORT);
+                } else {
+                    ptc.add_or_update_server(cmd_tokens[pos].substr(0, colon_pos),
+                                             static_cast<uint16_t>(std::stoul(cmd_tokens[pos].substr(colon_pos+1),nullptr,0)));
+                }
+                pos++;
+            }
+            bool ret = false;
+            ret = perftest_get_by_time(ptc, object_pool_pathname, member_selection_policy, ms_in_past, max_rate, duration_sec, "timestamp.log");
             return ret;
         }
     },

--- a/src/service/client.cpp
+++ b/src/service/client.cpp
@@ -678,7 +678,7 @@ template <typename SubgroupType>
 bool perftest_get(PerfTestClient& ptc,
                   const std::string& object_pool_pathname,
                   ExternalClientToCascadeServerMapping ec2cs,
-                  uint64_t log_depth,
+                  int32_t log_depth,
                   uint64_t ops_threshold,
                   uint64_t duration_secs,
                   const std::string& output_filename) {
@@ -695,7 +695,7 @@ bool perftest_get(PerfTestClient& ptc,
                   uint32_t subgroup_index,
                   uint32_t shard_index,
                   ExternalClientToCascadeServerMapping ec2cs,
-                  uint64_t log_depth,
+                  int32_t log_depth,
                   uint64_t ops_threshold,
                   uint64_t duration_secs,
                   const std::string& output_filename) {
@@ -1656,7 +1656,7 @@ std::vector<command_entry_t> commands =
             } else if (cmd_tokens[3] == "ROUNDROBIN") {
                 member_selection_policy = ExternalClientToCascadeServerMapping::ROUNDROBIN;
             }
-            uint64_t log_depth = std::stoul(cmd_tokens[4], nullptr, 0);
+            int32_t log_depth = std::stoi(cmd_tokens[4], nullptr, 0);
             uint64_t max_rate = std::stoul(cmd_tokens[5], nullptr, 0);
             uint64_t duration_sec = std::stoul(cmd_tokens[6], nullptr, 0);
 
@@ -1753,7 +1753,7 @@ std::vector<command_entry_t> commands =
             } else if (cmd_tokens[4] == "ROUNDROBIN") {
                 member_selection_policy = ExternalClientToCascadeServerMapping::ROUNDROBIN;
             }
-            uint64_t log_depth = std::stoul(cmd_tokens[5], nullptr, 0);
+            int32_t log_depth = std::stoi(cmd_tokens[5], nullptr, 0);
             uint64_t max_rate = std::stoul(cmd_tokens[6], nullptr, 0);
             uint64_t duration_sec = std::stoul(cmd_tokens[7], nullptr, 0);
 

--- a/src/service/perftest.cpp
+++ b/src/service/perftest.cpp
@@ -595,6 +595,8 @@ PerfTestServer::PerfTestServer(ServiceClientAPI& capi, uint16_t port):
         uint32_t num_distinct_objects = std::min(static_cast<uint64_t>(max_num_distinct_objects), max_workload_memory / object_size);
         // Ensure adding log_depth versions to all the workload objects won't run out of log space, in case log_depth is large
         num_distinct_objects = std::min(num_distinct_objects, derecho::getConfUInt32(derecho::Conf::PERS_MAX_LOG_ENTRY) / (log_depth + 1));
+        num_distinct_objects = std::min(static_cast<uint64_t>(num_distinct_objects),
+                                        derecho::getConfUInt64(derecho::Conf::PERS_MAX_DATA_SIZE) / (object_size * (log_depth + 1)));
         make_workload<std::string, ObjectWithStringKey>(object_size, num_distinct_objects, "raw_key_", objects);
         // Wait for start time
         int64_t sleep_us = (start_sec * 1e9 - static_cast<int64_t>(get_walltime())) / 1e3;
@@ -810,6 +812,8 @@ PerfTestServer::PerfTestServer(ServiceClientAPI& capi, uint16_t port):
         uint32_t num_distinct_objects = std::min(static_cast<uint64_t>(max_num_distinct_objects), max_workload_memory / object_size);
         // Ensure adding log_depth versions to all the workload objects won't run out of log space, in case log_depth is large
         num_distinct_objects = std::min(num_distinct_objects, derecho::getConfUInt32(derecho::Conf::PERS_MAX_LOG_ENTRY) / (log_depth + 1));
+        num_distinct_objects = std::min(static_cast<uint64_t>(num_distinct_objects),
+                                        derecho::getConfUInt64(derecho::Conf::PERS_MAX_DATA_SIZE) / (object_size * (log_depth + 1)));
         make_workload<std::string, ObjectWithStringKey>(object_size, num_distinct_objects,
                                                         object_pool_pathname + "/key_", objects);
         // Wait for start time

--- a/src/service/perftest.cpp
+++ b/src/service/perftest.cpp
@@ -16,6 +16,7 @@ namespace cascade {
 #ifdef ENABLE_EVALUATION
 #define TLT_READY_TO_SEND       (11000)
 #define TLT_EC_SENT             (12000)
+#define TLT_EC_GET_FINISHED     (12042)
 /////////////////////////////////////////////////////
 // PerfTestClient/PerfTestServer implementation    //
 /////////////////////////////////////////////////////
@@ -230,6 +231,176 @@ bool PerfTestServer::eval_trigger_put(uint64_t max_operation_per_second,
         message_id ++;
     }
 
+    return true;
+}
+
+bool PerfTestServer::eval_get(uint64_t log_depth,
+                              uint64_t max_operations_per_second,
+                              uint64_t duration_secs,
+                              uint32_t subgroup_type_index,
+                              uint32_t subgroup_index,
+                              uint32_t shard_index) {
+    debug_enter_func_with_args("max_ops={},duration={},subgroup_type_index={},subgroup_index={},shard_index={}",
+                               max_operations_per_second, duration_secs, subgroup_type_index, subgroup_index, shard_index);
+    // In case the test objects ever change type, use an alias for whatever type is in the objects vector
+    using ObjectType = std::decay_t<decltype(objects[0])>;
+    // Sending window variables
+    uint32_t window_size = derecho::getConfUInt32(derecho::Conf::DERECHO_P2P_WINDOW_SIZE);
+    uint32_t window_slots = window_size * 2;
+    std::mutex window_slots_mutex;
+    std::condition_variable window_slots_cv;
+    // Result future queue, which pairs message IDs with a future for that message
+    std::queue<std::pair<uint64_t, derecho::QueryResults<const ObjectType>>> futures;
+    std::mutex futures_mutex;
+    std::condition_variable futures_cv;
+    std::condition_variable window_cv;
+    // All sent flag
+    std::atomic<bool> all_sent(false);
+    // Node ID, used for logger calls
+    const node_id_t my_node_id = this->capi.get_my_id();
+    // Future consuming thread
+    std::thread query_thread(
+            [&]() {
+                std::unique_lock<std::mutex> futures_lck{futures_mutex};
+                while(!all_sent || (futures.size() > 0)) {
+                    // Wait for the futures queue to be non-empty, then swap it with pending_futures
+                    using namespace std::chrono_literals;
+                    while(!futures_cv.wait_for(futures_lck, 500ms, [&futures, &all_sent] { return (futures.size() > 0) || all_sent; }))
+                        ;
+                    std::decay_t<decltype(futures)> pending_futures;
+                    futures.swap(pending_futures);
+                    futures_lck.unlock();
+                    //+---------------------------------------+
+                    //|             QUEUE UNLOCKED            |
+                    // wait for each future in pending_futures, leaving futures unlocked
+                    while(pending_futures.size() > 0) {
+                        auto& replies = pending_futures.front().second.get();
+                        uint64_t message_id = pending_futures.front().first;
+                        // Get only the first reply
+                        for(auto& reply : replies) {
+                            reply.second.get();
+                            // This might not be an accurate time for when the query completed, depending on how long the thread waited to acquire the queue lock
+                            TimestampLogger::log(TLT_EC_GET_FINISHED, my_node_id, message_id, get_walltime());
+                            break;
+                        }
+                        pending_futures.pop();
+                        {
+                            std::lock_guard<std::mutex> window_slots_lock{window_slots_mutex};
+                            window_slots++;
+                        }
+                        window_slots_cv.notify_one();
+                    }
+                    //|            QUEUE UNLOCKED             |
+                    //+---------------------------------------+
+                    // Acquire lock on futures queue
+                    futures_lck.lock();
+                }
+            });
+    // Put test objects in the target subgroup/object pool, and record which version is log_depth back in the log
+    // NOTE: This only works if there is a single client! If there are multiple clients there will be num_clients * log_depth versions
+    std::vector<persistent::version_t> oldest_object_versions;
+    for(const auto& object : objects) {
+        using namespace derecho;
+        // Call put with either the object pool interface or the shard interface, and store the future here
+        // Use a unique_ptr to work around the fact that QueryResults has a move constructor but no default constructor
+        std::unique_ptr<QueryResults<cascade::version_tuple>> put_result_future;
+        if(subgroup_index == INVALID_SUBGROUP_INDEX || shard_index == INVALID_SHARD_INDEX) {
+            // put returns the QueryResults by value, so we have to move-construct it into a unique_ptr
+            put_result_future = std::make_unique<QueryResults<cascade::version_tuple>>(std::move(this->capi.put(object)));
+        } else {
+            // Manual copy of on_subgroup_type_index macro so I can use make_unique
+            std::type_index tindex = std::decay_t<decltype(capi)>::subgroup_type_order.at(subgroup_type_index);
+            if(std::type_index(typeid(VolatileCascadeStoreWithStringKey)) == tindex) {
+                put_result_future = std::make_unique<QueryResults<cascade::version_tuple>>(
+                    std::move(this->capi.template put<VolatileCascadeStoreWithStringKey>(object, subgroup_index, shard_index)));
+            } else if(std::type_index(typeid(PersistentCascadeStoreWithStringKey)) == tindex) {
+                put_result_future = std::make_unique<QueryResults<cascade::version_tuple>>(
+                    std::move(this->capi.template put<PersistentCascadeStoreWithStringKey>(object, subgroup_index, shard_index)));
+            } else if(std::type_index(typeid(TriggerCascadeNoStoreWithStringKey)) == tindex) {
+                put_result_future = std::make_unique<QueryResults<cascade::version_tuple>>(
+                    std::move(this->capi.template put<TriggerCascadeNoStoreWithStringKey>(object, subgroup_index, shard_index)));
+            } else {
+                throw derecho::derecho_exception(std::string("Unknown type_index:") + tindex.name());
+            }
+        }
+        // Save the version assigned to this version of the object, which will become the oldest version in the log
+        auto& replies = put_result_future->get();
+        derecho::cascade::version_tuple object_version_tuple = replies.begin()->second.get();
+        oldest_object_versions.emplace_back(std::get<0>(object_version_tuple));
+        dbg_default_debug("eval_get: Object {} got version {}, putting {} more versions in front of it", object.get_key_ref(), std::get<0>(object_version_tuple), log_depth);
+        // Call put_and_forget repeatedly on the same object to give it multiple newer versions in the log, up to the depth needed
+        for(uint64_t i = 0; i < log_depth; ++i) {
+            if(subgroup_index == INVALID_SUBGROUP_INDEX || shard_index == INVALID_SHARD_INDEX) {
+                this->capi.put_and_forget(object);
+            } else {
+                on_subgroup_type_index(std::decay_t<decltype(capi)>::subgroup_type_order.at(subgroup_type_index),
+                                       this->capi.template put_and_forget, object, subgroup_index, shard_index);
+            }
+        }
+    }
+
+    dbg_default_info("eval_get: Puts complete, ready to start experiment");
+
+    // Timing control variables
+    uint64_t interval_ns = (max_operations_per_second == 0) ? 0 : static_cast<uint64_t>(1e9 / max_operations_per_second);
+    uint64_t next_ns = get_walltime();
+    uint64_t end_ns = next_ns + duration_secs * 1000000000ull;
+    uint64_t message_id = this->capi.get_my_id() * 1000000000ull;
+
+    while(true) {
+        uint64_t now_ns = get_walltime();
+        if(now_ns > end_ns) {
+            all_sent.store(true);
+            break;
+        }
+        // we leave 500 ns for loop overhead.
+        if(now_ns + 500 < next_ns) {
+            usleep((next_ns - now_ns - 500) / 1000);  // sleep in microseconds.
+        }
+        {
+            std::unique_lock<std::mutex> window_slots_lock{window_slots_mutex};
+            window_slots_cv.wait(window_slots_lock, [&window_slots] { return (window_slots > 0); });
+            window_slots--;
+        }
+        next_ns += interval_ns;
+        // Since each loop iteration creates its own future_appender, capture the message_id by copy
+        std::function<void(QueryResults<const ObjectType>&&)> future_appender =
+                [&futures, &futures_mutex, &futures_cv, message_id](
+                        QueryResults<const ObjectType>&& query_results) {
+                    std::unique_lock<std::mutex> lock{futures_mutex};
+                    futures.emplace(message_id, std::move(query_results));
+                    lock.unlock();
+                    futures_cv.notify_one();
+                };
+        std::size_t cur_object_index = now_ns % NUMBER_OF_DISTINCT_OBJECTS;
+        // NOTE: Setting the message ID on the object won't do anything because we're doing a Get, not a Put
+        TimestampLogger::log(TLT_READY_TO_SEND, my_node_id, message_id, get_walltime());
+        // With either the object pool interface or the shard interface, further decide whether to request the current version or an old version
+        if(subgroup_index == INVALID_SUBGROUP_INDEX || shard_index == INVALID_SHARD_INDEX) {
+            if(log_depth == 0) {
+                future_appender(this->capi.get(objects.at(cur_object_index).get_key_ref()));
+            } else {
+                future_appender(this->capi.get(objects.at(cur_object_index).get_key_ref(), oldest_object_versions.at(cur_object_index)));
+            }
+        } else {
+            if(log_depth == 0) {
+                on_subgroup_type_index_with_return(
+                        std::decay_t<decltype(capi)>::subgroup_type_order.at(subgroup_type_index),
+                        future_appender,
+                        this->capi.template get, objects.at(cur_object_index).get_key_ref(), CURRENT_VERSION, true, subgroup_index, shard_index);
+            } else {
+                on_subgroup_type_index_with_return(
+                        std::decay_t<decltype(capi)>::subgroup_type_order.at(subgroup_type_index),
+                        future_appender,
+                        this->capi.template get, objects.at(cur_object_index).get_key_ref(), oldest_object_versions.at(cur_object_index), true, subgroup_index, shard_index);
+            }
+        }
+        TimestampLogger::log(TLT_EC_SENT, my_node_id, message_id, get_walltime());
+        message_id++;
+    }
+    dbg_default_info("eval_get: All messages sent, waiting for queries to complete");
+    // wait for all pending futures.
+    query_thread.join();
     return true;
 }
 
@@ -486,15 +657,15 @@ PerfTestServer::PerfTestServer(ServiceClientAPI& capi, uint16_t port):
     // @param output_filename
     //
     // @return true/false indicating if the RPC call is successful.
-    server.bind("perf_trigger_put_to_objectpool",[this](
-        const std::string&  object_pool_pathname,
-        uint32_t            policy,
-        const std::vector<node_id_t>&  user_specified_node_ids, // one per shard
-        double              read_write_ratio,
-        uint64_t            max_operation_per_second,
-        int64_t             start_sec,
-        uint64_t            duration_secs,
-        const std::string&  output_filename) {
+    server.bind("perf_trigger_put_to_objectpool", [this](
+                                                          const std::string& object_pool_pathname,
+                                                          uint32_t policy,
+                                                          const std::vector<node_id_t>& user_specified_node_ids,  // one per shard
+                                                          double read_write_ratio,
+                                                          uint64_t max_operation_per_second,
+                                                          int64_t start_sec,
+                                                          uint64_t duration_secs,
+                                                          const std::string& output_filename) {
 
         auto object_pool = this->capi.find_object_pool(object_pool_pathname);
 
@@ -524,6 +695,62 @@ PerfTestServer::PerfTestServer(ServiceClientAPI& capi, uint16_t port):
             return false;
         }
     });
+    /**
+     * RPC function that runs perf_get using the object pool interface
+     *
+     * @param object_pool_pathname
+     * @param member_selection_policy
+     * @param user_specified_node_ids
+     * @param log_depth
+     * @param max_operations_per_second
+     * @param start_sec
+     * @param duration_secs
+     * @param output_filename
+     * @return true if experiment completed successfully, false if there was an error
+     */
+    server.bind("perf_get_to_objectpool", [this](const std::string& object_pool_pathname,
+                                                 uint32_t member_selection_policy,
+                                                 const std::vector<node_id_t>& user_specified_node_ids,
+                                                 uint64_t log_depth,
+                                                 uint64_t max_operations_per_second,
+                                                 int64_t start_sec,
+                                                 uint64_t duration_secs,
+                                                 const std::string& output_filename) {
+        auto object_pool = this->capi.find_object_pool(object_pool_pathname);
+        uint32_t number_of_shards;
+        // Set up the shard member selection policy
+        std::type_index object_pool_type_index = std::decay_t<decltype(capi)>::subgroup_type_order.at(object_pool.subgroup_type_index);
+        on_subgroup_type_index(object_pool_type_index,
+                               number_of_shards = this->capi.template get_number_of_shards, object_pool.subgroup_index);
+        if(user_specified_node_ids.size() < number_of_shards) {
+            throw derecho::derecho_exception(std::string("the size of 'user_specified_node_ids' argument does not match shard number."));
+        }
+        for(uint32_t shard_index = 0; shard_index < number_of_shards; shard_index++) {
+            on_subgroup_type_index(object_pool_type_index,
+                                   this->capi.template set_member_selection_policy, object_pool.subgroup_index, shard_index, static_cast<ShardMemberSelectionPolicy>(member_selection_policy), user_specified_node_ids.at(shard_index));
+        }
+        // Create workload objects
+        objects.clear();
+        make_workload<std::string, ObjectWithStringKey>(derecho::getConfUInt32(derecho::Conf::DERECHO_MAX_P2P_REQUEST_PAYLOAD_SIZE), object_pool_pathname + "/key_", objects);
+        // Wait for start time
+        int64_t sleep_us = (start_sec * 1e9 - static_cast<int64_t>(get_walltime())) / 1e3;
+        if(sleep_us > 1) {
+            usleep(sleep_us);
+        }
+        // Run experiment, then log timestamps
+        try {
+            if(this->eval_get(log_depth, max_operations_per_second, duration_secs, object_pool.subgroup_type_index)) {
+                TimestampLogger::flush(output_filename);
+                return true;
+            } else {
+                return false;
+            }
+        } catch(const std::exception& e) {
+            std::cerr << "eval_get failed with exception: " << typeid(e).name() << ": " << e.what() << std::endl;
+            return false;
+        }
+    });
+
     // start the worker thread asynchronously
     server.async_run(1);
 }

--- a/src/service/perftest.hpp
+++ b/src/service/perftest.hpp
@@ -100,7 +100,7 @@ private:
      * @param shard_index Specific shard to target. If subgroup_index and shard_index are both invalid, the test will use the object pool API.
      * @return true if experiment completes successfully, false on error
      */
-    bool eval_get(uint64_t log_depth,
+    bool eval_get(uint32_t log_depth,
                   uint64_t max_operations_per_second,
                   uint64_t duration_secs,
                   uint32_t subgroup_type_index,
@@ -221,7 +221,7 @@ public:
     template<typename SubgroupType>
     bool perf_get(const std::string& object_pool_pathname,
                   ExternalClientToCascadeServerMapping client_server_mapping,
-                  uint64_t log_depth,
+                  uint32_t log_depth,
                   uint64_t ops_threshold,
                   uint64_t duration_secs,
                   const std::string& output_filename);
@@ -274,7 +274,7 @@ public:
     bool perf_get(uint32_t  subgroup_index,
                   uint32_t  shard_index,
                   ExternalClientToCascadeServerMapping client_server_mapping,
-                  uint64_t log_depth,
+                  uint32_t log_depth,
                   uint64_t ops_threshold,
                   uint64_t duration_secs,
                   const std::string& output_filename);
@@ -366,7 +366,7 @@ bool PerfTestClient::perf_put(PutType               put_type,
 template <typename SubgroupType>
 bool PerfTestClient::perf_get(const std::string& object_pool_pathname,
                               ExternalClientToCascadeServerMapping client_server_mapping,
-                              uint64_t log_depth,
+                              uint32_t log_depth,
                               uint64_t ops_threshold,
                               uint64_t duration_secs,
                               const std::string& output_filename) {
@@ -505,7 +505,7 @@ template <typename SubgroupType>
 bool PerfTestClient::perf_get(uint32_t subgroup_index,
                               uint32_t shard_index,
                               ExternalClientToCascadeServerMapping client_server_mapping,
-                              uint64_t log_depth,
+                              uint32_t log_depth,
                               uint64_t ops_threshold,
                               uint64_t duration_secs,
                               const std::string& output_filename) {

--- a/src/service/perftest.hpp
+++ b/src/service/perftest.hpp
@@ -91,8 +91,10 @@ private:
      *
      * @param log_depth The number of versions in the past to request on each read.
      * The put() operations that run before starting the experiment will ensure
-     * there are at least this many versions in the log. 0 means to request the current version,
-     * and is the only supported option when the subgroup type is "volatile."
+     * there are at least this many versions in the log. 0 means to request the
+     * current version, while -1 means to call multi_get() (which does a multicast
+     * to ensure it gets the latest version) rather than get(). Log depths greater
+     * than 0 are not supported when the subgroup type is "volatile."
      * @param max_operations_per_second Maximum message rate
      * @param duration_secs Experiment duration in seconds
      * @param subgroup_type_index Index of the targeted subgroup type within the Cascade template parameters
@@ -100,7 +102,7 @@ private:
      * @param shard_index Specific shard to target. If subgroup_index and shard_index are both invalid, the test will use the object pool API.
      * @return true if experiment completes successfully, false on error
      */
-    bool eval_get(uint32_t log_depth,
+    bool eval_get(int32_t log_depth,
                   uint64_t max_operations_per_second,
                   uint64_t duration_secs,
                   uint32_t subgroup_type_index,
@@ -207,8 +209,9 @@ public:
      *        The policy for mapping external clients to shard members
      * @param log_depth
      *        The number of versions in the past to request in each get request.
-     *        0 means to request the current version, and is the only supported
-     *        value when SubgroupType is not PersistentCascadeStore.
+     *        0 means to request the current version, while -1 means to call
+     *        multi_get() to get the latest version. Depths greater than 0 are
+     *        not supported when SubgroupType is not PersistentCascadeStore.
      * @param ops_threshold
      *        The maximum number of operations per second to submit from each client
      * @param duration_secs
@@ -221,7 +224,7 @@ public:
     template<typename SubgroupType>
     bool perf_get(const std::string& object_pool_pathname,
                   ExternalClientToCascadeServerMapping client_server_mapping,
-                  uint32_t log_depth,
+                  int32_t log_depth,
                   uint64_t ops_threshold,
                   uint64_t duration_secs,
                   const std::string& output_filename);
@@ -259,8 +262,9 @@ public:
      *        The policy for mapping external clients to shard members
      * @param log_depth
      *        The number of versions in the past to request in each get request.
-     *        0 means to request the current version, and is the only supported
-     *        value when SubgroupType is not PersistentCascadeStore.
+     *        0 means to request the current version, while -1 means to call
+     *        multi_get() to get the latest version. Depths greater than 0 are
+     *        not supported when SubgroupType is not PersistentCascadeStore.
      * @param ops_threshold
      *        The maximum number of operations per second to submit from each client
      * @param duration_secs
@@ -274,7 +278,7 @@ public:
     bool perf_get(uint32_t  subgroup_index,
                   uint32_t  shard_index,
                   ExternalClientToCascadeServerMapping client_server_mapping,
-                  uint32_t log_depth,
+                  int32_t log_depth,
                   uint64_t ops_threshold,
                   uint64_t duration_secs,
                   const std::string& output_filename);
@@ -366,7 +370,7 @@ bool PerfTestClient::perf_put(PutType               put_type,
 template <typename SubgroupType>
 bool PerfTestClient::perf_get(const std::string& object_pool_pathname,
                               ExternalClientToCascadeServerMapping client_server_mapping,
-                              uint32_t log_depth,
+                              int32_t log_depth,
                               uint64_t ops_threshold,
                               uint64_t duration_secs,
                               const std::string& output_filename) {
@@ -505,7 +509,7 @@ template <typename SubgroupType>
 bool PerfTestClient::perf_get(uint32_t subgroup_index,
                               uint32_t shard_index,
                               ExternalClientToCascadeServerMapping client_server_mapping,
-                              uint32_t log_depth,
+                              int32_t log_depth,
                               uint64_t ops_threshold,
                               uint64_t duration_secs,
                               const std::string& output_filename) {

--- a/src/service/perftest.hpp
+++ b/src/service/perftest.hpp
@@ -11,11 +11,22 @@ namespace derecho {
 namespace cascade {
 
 #define PERFTEST_PORT               (18720)
-#define NUMBER_OF_DISTINCT_OBJECTS  (4096)
 #define INVALID_SUBGROUP_INDEX      (std::numeric_limits<uint32_t>::max())
 #define INVALID_SHARD_INDEX         (std::numeric_limits<uint32_t>::max())
 
 class PerfTestServer {
+public:
+    /**
+     * The maximum number of distinct test objects to create for test workloads.
+     * Fewer will be created if the total size of the objects would be greater than
+     * max_workload_memory.
+     */
+    static const uint32_t max_num_distinct_objects = 4096;
+    /**
+     * The maximum number of bytes that should be used to create workload objects.
+     * This prevents the client from running out of RAM creating large objects.
+     */
+    static constexpr uint64_t max_workload_memory = 16 * 1073741824L;
 private:
     ServiceClientAPI&   capi;
     ::rpc::server       server;

--- a/src/service/perftest.hpp
+++ b/src/service/perftest.hpp
@@ -326,7 +326,6 @@ public:
      *        How long each client should run the test for
      * @param output_filename
      *        The output file to write timestamps to after running the test
-     * @param output_filename
      * @return true for a successful run, false for a failed run
      */
     template <typename SubgroupType>

--- a/src/service/perftest.hpp
+++ b/src/service/perftest.hpp
@@ -73,6 +73,29 @@ private:
                           uint32_t shard_index=INVALID_SHARD_INDEX);
 
 
+    /**
+     * Evaluate get operations. This function will first call put() a sufficient
+     * number of times to create a log of the requested depth for each key, then
+     * measure the duration of a sequence of get() operations.
+     *
+     * @param log_depth The number of versions in the past to request on each read.
+     * The put() operations that run before starting the experiment will ensure
+     * there are at least this many versions in the log. 0 means to request the current version,
+     * and is the only supported option when the subgroup type is "volatile."
+     * @param max_operations_per_second Maximum message rate
+     * @param duration_secs Experiment duration in seconds
+     * @param subgroup_type_index Index of the targeted subgroup type within the Cascade template parameters
+     * @param subgroup_index Specific subgroup to target. If subgroup_index and shard_index are both invalid, the test will use the object pool API.
+     * @param shard_index Specific shard to target. If subgroup_index and shard_index are both invalid, the test will use the object pool API.
+     * @return true if experiment completes successfully, false on error
+     */
+    bool eval_get(uint64_t log_depth,
+                  uint64_t max_operations_per_second,
+                  uint64_t duration_secs,
+                  uint32_t subgroup_type_index,
+                  uint32_t subgroup_index=INVALID_SUBGROUP_INDEX,
+                  uint32_t shard_index=INVALID_SHARD_INDEX);
+
 public:
     /**
      * Constructor
@@ -162,6 +185,35 @@ public:
                   uint64_t              ops_threshold,
                   uint64_t              duration_secs,
                   const std::string&    output_file);
+
+    /**
+     * Object Pool performance test using only gets
+     *
+     * @tparam SubgroupType The type of the subgroup containing the object pool
+     * @param object_pool_pathname
+     *        The object pool to test
+     * @param client_server_mapping
+     *        The policy for mapping external clients to shard members
+     * @param log_depth
+     *        The number of versions in the past to request in each get request.
+     *        0 means to request the current version, and is the only supported
+     *        value when SubgroupType is not PersistentCascadeStore.
+     * @param ops_threshold
+     *        The maximum number of operations per second to submit from each client
+     * @param duration_secs
+     *        How long each client should run the test for
+     * @param output_filename
+     *        The output file to write timestamps to after running the test
+     * @return true for a successful run,
+     * @return false for a failed run
+     */
+    template<typename SubgroupType>
+    bool perf_get(const std::string& object_pool_pathname,
+                  ExternalClientToCascadeServerMapping client_server_mapping,
+                  uint64_t log_depth,
+                  uint64_t ops_threshold,
+                  uint64_t duration_secs,
+                  const std::string& output_filename);
     /**
      * Single Shard Performance testing, using put with return
      * @param put_type
@@ -265,6 +317,73 @@ bool PerfTestClient::perf_put(PutType               put_type,
 
     // 3 - flush server timestamps
     capi.template dump_timestamp(output_filename,object_pool_pathname);
+
+    debug_leave_func();
+    return ret;
+}
+
+template <typename SubgroupType>
+bool PerfTestClient::perf_get(const std::string& object_pool_pathname,
+                              ExternalClientToCascadeServerMapping client_server_mapping,
+                              uint64_t log_depth,
+                              uint64_t ops_threshold,
+                              uint64_t duration_secs,
+                              const std::string& output_filename) {
+    debug_enter_func_with_args("object_pool_pathname={},ec2cs={},log_depth={},ops_threshold={},duration_secs={},output_filename={}",
+                               object_pool_pathname, static_cast<uint32_t>(client_server_mapping), log_depth, ops_threshold, duration_secs, output_filename);
+    bool ret = true;
+    // 1 - decides on shard membership policy for the "policy" and "user_specified_node_ids" argument for rpc calls.
+    ShardMemberSelectionPolicy policy = ShardMemberSelectionPolicy::Random;
+    auto object_pool = capi.find_object_pool(object_pool_pathname);
+    if(!object_pool.is_valid() || object_pool.is_null()) {
+        throw derecho::derecho_exception("Cannot find object pool:" + object_pool_pathname);
+    }
+    uint32_t number_of_shards = capi.get_number_of_shards<SubgroupType>(object_pool.subgroup_index);
+    std::map<std::pair<std::string, uint16_t>, std::vector<node_id_t>> user_specified_node_ids;
+    for(const auto& kv : connections) {
+        user_specified_node_ids.emplace(kv.first, std::vector<node_id_t>{number_of_shards});
+    }
+    switch(client_server_mapping) {
+        case ExternalClientToCascadeServerMapping::FIXED:
+            policy = ShardMemberSelectionPolicy::UserSpecified;
+            for(uint32_t shard_index = 0; shard_index < number_of_shards; shard_index++) {
+                auto shard_members = capi.template get_shard_members<SubgroupType>(object_pool.subgroup_index, shard_index);
+                uint32_t connection_index = 0;
+                for(const auto& kv : connections) {
+                    user_specified_node_ids[kv.first].at(shard_index) = shard_members.at(connection_index % shard_members.size());
+                    connection_index++;
+                }
+            }
+            break;
+        case ExternalClientToCascadeServerMapping::RANDOM:
+            policy = ShardMemberSelectionPolicy::Random;
+            break;
+        case ExternalClientToCascadeServerMapping::ROUNDROBIN:
+            policy = ShardMemberSelectionPolicy::RoundRobin;
+            break;
+    };
+    // 2 - send requests and wait for response
+
+    std::string rpc_cmd = "perf_get_to_objectpool";
+    int64_t start_sec = static_cast<int64_t>(get_walltime()) / 1e9 + 5;  // wait for 5 second so that the rpc servers are started.
+
+    std::map<std::pair<std::string, uint16_t>, std::future<RPCLIB_MSGPACK::object_handle>> futures;
+    for(auto& kv : connections) {
+        futures.emplace(kv.first, kv.second->async_call(rpc_cmd,
+                                                        object_pool_pathname,
+                                                        static_cast<uint32_t>(policy),
+                                                        user_specified_node_ids.at(kv.first),
+                                                        log_depth,
+                                                        ops_threshold,
+                                                        start_sec,
+                                                        duration_secs,
+                                                        output_filename));
+    }
+
+    ret = check_rpc_futures(std::move(futures));
+
+    // 3 - flush server timestamps
+    capi.template dump_timestamp(output_filename, object_pool_pathname);
 
     debug_leave_func();
     return ret;


### PR DESCRIPTION
This branch contains the new perftest commands I wrote to test get() performance for the most recent Cascade submission. It also includes some general improvements to the perftest system, such as the ability to choose a number of test objects other than 4096 when calling the make_workload function. The perf_get and perf_get_by_time commands are complete and documented, with an interface very similar to the existing perf_put commands, so I think they are safe to merge into master.