### PR TITLE
Making sure a recently created object pool is fetched when refreshing metadata cache

### DIFF
--- a/include/cascade/detail/service_impl.hpp
+++ b/include/cascade/detail/service_impl.hpp
@@ -1720,7 +1720,7 @@ void ServiceClient<CascadeTypes...>::refresh_object_pool_metadata_cache() {
     std::unordered_map<std::string,ObjectPoolMetadataCacheEntry> refreshed_metadata;
     uint32_t num_shards = this->template get_number_of_shards<CascadeMetadataService<CascadeTypes...>>(METADATA_SERVICE_SUBGROUP_INDEX);
     for(uint32_t shard=0;shard<num_shards;shard++) {
-        auto results = this->template list_keys<CascadeMetadataService<CascadeTypes...>>(CURRENT_VERSION,true,METADATA_SERVICE_SUBGROUP_INDEX,shard);
+        auto results = this->template multi_list_keys<CascadeMetadataService<CascadeTypes...>>(METADATA_SERVICE_SUBGROUP_INDEX,shard);
         for (auto& reply : results.get()) { // only once
             for(auto& key: reply.second.get()) { // iterate over keys
                 // we only read the stable version.

--- a/include/cascade/detail/service_impl.hpp
+++ b/include/cascade/detail/service_impl.hpp
@@ -1750,15 +1750,16 @@ derecho::rpc::QueryResults<version_tuple> ServiceClient<CascadeTypes...>::create
         throw derecho::derecho_exception(std::string("Create object pool failed because SubgroupType is invalid:")+typeid(SubgroupType).name());
     }
     ObjectPoolMetadata<CascadeTypes...> opm(pathname,subgroup_type_index,subgroup_index,sharding_policy,object_locations,affinity_set_regex,false);
-    // clear local cache entry.
-    std::shared_lock<std::shared_mutex> rlck(object_pool_metadata_cache_mutex);
-    if (object_pool_metadata_cache.find(pathname)==object_pool_metadata_cache.end()) {
-        rlck.unlock();
-    } else {
-        rlck.unlock();
-        std::unique_lock<std::shared_mutex> wlck(object_pool_metadata_cache_mutex);
+
+    // insert new entry in the cache
+    ServiceClient<CascadeTypes...>::ObjectPoolMetadataCacheEntry opm_entry(opm);
+    std::unique_lock<std::shared_mutex> wlck(object_pool_metadata_cache_mutex);
+    if (object_pool_metadata_cache.find(pathname)!=object_pool_metadata_cache.end()) {
         object_pool_metadata_cache.erase(pathname);
     }
+    object_pool_metadata_cache.emplace(pathname,opm_entry);
+    wlck.unlock();
+
     // determine the shard index by hashing
     uint32_t metadata_service_shard_index = std::hash<std::string>{}(pathname) % this->template get_number_of_shards<CascadeMetadataService<CascadeTypes...>>(METADATA_SERVICE_SUBGROUP_INDEX);
 


### PR DESCRIPTION
After creating a pool, the external client might not be able to see the pool immediately because it's not getting stable yet. This change solves the issue by using multi_list_keys (instead of list_keys) to ensure a just created object pool is stable. This way, refresh_object_pool_metadata_cache() will be able to fetch the just created pool, which can then be used immediately.