### PR TITLE
Removing a duplicated 'apply_ordered_put' on applying delta 

### DIFF
--- a/include/cascade/detail/delta_store_core_impl.hpp
+++ b/include/cascade/detail/delta_store_core_impl.hpp
@@ -93,7 +93,6 @@ void DeltaCascadeStoreCore<KT, VT, IK, IV>::finalizeCurrentDelta(const persisten
 
 template <typename KT, typename VT, KT* IK, VT* IV>
 void DeltaCascadeStoreCore<KT, VT, IK, IV>::applyDelta(uint8_t const* const delta) {
-    apply_ordered_put(*mutils::from_bytes<VT>(nullptr, delta));
     mutils::deserialize_and_run(nullptr, delta, [this](const VT& value) {
         this->apply_ordered_put(value);
     });


### PR DESCRIPTION
Thank you @tgarr for finding this issue. This is a bug I introduced [4 years ago](https://github.com/Derecho-Project/cascade/blame/d255289ee9234162b373dd2b104a5fdeb535ed0d/include/cascade/detail/cascade_impl.hpp#L752-L756) when I try to change the 'apply_ordered_put' to a zero copy version. But I forget to remove the copy version of it. This will add overhead on system restart and node joining but not affect the runtime performance of Cascade.