### PR TITLE
Adapting to renamed configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ We recommend coordinating with [Weijia Song](mailto:songweijia@gmail.com) if you
 - Python 3.8 or newer and [pybind11](https://github.com/pybind/pybind11) (Optional for Python API)
 - OpenJDK 11.06 or newer. On Ubuntu, use `apt install openjdk-11-jdk` to install it. (Optional for Java API)
 - .NET Framework 6x. Please follow the instructions from Microsoft to install it based on Linux distro [here](https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu). (Optional for C\# API)
-- Derecho v2.4.0 Plesae follow this [document](http://github.com/Derecho-Project/derecho) to install Derecho. Note: this cascade version replies on Derecho commit ef3043f on the master branch.
+- Derecho v2.4.0 Plesae follow this [document](http://github.com/Derecho-Project/derecho) to install Derecho. Note: this cascade version replies on Derecho commit 45d81d0 on the master branch.
 
 ## Build Cascade
 1) Download Cascade Source Code

--- a/src/applications/standalone/console_printer_udl/cfg/n0/derecho.cfg
+++ b/src/applications/standalone/console_printer_udl/cfg/n0/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 0
 # my local ip address

--- a/src/applications/standalone/console_printer_udl/cfg/n1/derecho.cfg
+++ b/src/applications/standalone/console_printer_udl/cfg/n1/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 1
 # my local ip address

--- a/src/applications/standalone/console_printer_udl/cfg/n2/derecho.cfg
+++ b/src/applications/standalone/console_printer_udl/cfg/n2/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 2
 # my local ip address

--- a/src/applications/standalone/dairy_farm/dairy_farm_cfg/n0/derecho.cfg
+++ b/src/applications/standalone/dairy_farm/dairy_farm_cfg/n0/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 0
 # my local ip address

--- a/src/applications/standalone/dairy_farm/dairy_farm_cfg/n1/derecho.cfg
+++ b/src/applications/standalone/dairy_farm/dairy_farm_cfg/n1/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 1
 # my local ip address

--- a/src/applications/standalone/dairy_farm/dairy_farm_cfg/n2/derecho.cfg
+++ b/src/applications/standalone/dairy_farm/dairy_farm_cfg/n2/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 2
 # my local ip address

--- a/src/applications/standalone/dairy_farm/dairy_farm_cfg/n3/derecho.cfg
+++ b/src/applications/standalone/dairy_farm/dairy_farm_cfg/n3/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 3
 # my local ip address

--- a/src/applications/standalone/dairy_farm/dairy_farm_cfg/n4/derecho.cfg
+++ b/src/applications/standalone/dairy_farm/dairy_farm_cfg/n4/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 4
 # my local ip address

--- a/src/applications/standalone/dds/cfg/n0/derecho.cfg
+++ b/src/applications/standalone/dds/cfg/n0/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 0
 # my local ip address

--- a/src/applications/standalone/dds/cfg/n1/derecho.cfg
+++ b/src/applications/standalone/dds/cfg/n1/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 1
 # my local ip address

--- a/src/applications/standalone/dds/cfg/n2/derecho.cfg
+++ b/src/applications/standalone/dds/cfg/n2/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 2
 # my local ip address

--- a/src/applications/standalone/dds/cfg/n3/derecho.cfg
+++ b/src/applications/standalone/dds/cfg/n3/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 3
 # my local ip address

--- a/src/applications/standalone/kvs_client/cfg/n0/derecho.cfg
+++ b/src/applications/standalone/kvs_client/cfg/n0/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 0
 # my local ip address

--- a/src/applications/standalone/kvs_client/cfg/n1/derecho.cfg
+++ b/src/applications/standalone/kvs_client/cfg/n1/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 1
 # my local ip address

--- a/src/applications/standalone/kvs_client/cfg/n2/derecho.cfg
+++ b/src/applications/standalone/kvs_client/cfg/n2/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 2
 # my local ip address

--- a/src/applications/standalone/notification/cfg/n0/derecho.cfg
+++ b/src/applications/standalone/notification/cfg/n0/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 0
 # my local ip address

--- a/src/applications/standalone/notification/cfg/n1/derecho.cfg
+++ b/src/applications/standalone/notification/cfg/n1/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 1
 # my local ip address

--- a/src/applications/standalone/notification/cfg/n2/derecho.cfg
+++ b/src/applications/standalone/notification/cfg/n2/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 2
 # my local ip address

--- a/src/applications/tests/cascade_as_subgroup_classes/cli_example_cfg/n0/derecho.cfg
+++ b/src/applications/tests/cascade_as_subgroup_classes/cli_example_cfg/n0/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 0
 # my local ip address

--- a/src/applications/tests/cascade_as_subgroup_classes/cli_example_cfg/n1/derecho.cfg
+++ b/src/applications/tests/cascade_as_subgroup_classes/cli_example_cfg/n1/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 1
 # my local ip address

--- a/src/applications/tests/cascade_as_subgroup_classes/cli_example_cfg/n2/derecho.cfg
+++ b/src/applications/tests/cascade_as_subgroup_classes/cli_example_cfg/n2/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 2
 # my local ip address

--- a/src/applications/tests/cascade_as_subgroup_classes/cli_example_cfg/n3/derecho.cfg
+++ b/src/applications/tests/cascade_as_subgroup_classes/cli_example_cfg/n3/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 3
 # my local ip address

--- a/src/applications/tests/pipeline/trigger_put_pipeline_cfg/n0/derecho.cfg
+++ b/src/applications/tests/pipeline/trigger_put_pipeline_cfg/n0/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 0
 # my local ip address

--- a/src/applications/tests/pipeline/trigger_put_pipeline_cfg/n1/derecho.cfg
+++ b/src/applications/tests/pipeline/trigger_put_pipeline_cfg/n1/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 1
 # my local ip address

--- a/src/applications/tests/pipeline/trigger_put_pipeline_cfg/n2/derecho.cfg
+++ b/src/applications/tests/pipeline/trigger_put_pipeline_cfg/n2/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 2
 # my local ip address

--- a/src/applications/tests/user_defined_logic/console_printer_cfg/n0/derecho.cfg
+++ b/src/applications/tests/user_defined_logic/console_printer_cfg/n0/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 0
 # my local ip address

--- a/src/applications/tests/user_defined_logic/console_printer_cfg/n1/derecho.cfg
+++ b/src/applications/tests/user_defined_logic/console_printer_cfg/n1/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 1
 # my local ip address

--- a/src/applications/tests/user_defined_logic/console_printer_cfg/n2/derecho.cfg
+++ b/src/applications/tests/user_defined_logic/console_printer_cfg/n2/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 2
 # my local ip address

--- a/src/applications/tests/user_defined_logic/console_printer_cfg/n3/derecho.cfg
+++ b/src/applications/tests/user_defined_logic/console_printer_cfg/n3/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 3
 # my local ip address

--- a/src/applications/tests/user_defined_logic/console_printer_cfg/n4/derecho.cfg
+++ b/src/applications/tests/user_defined_logic/console_printer_cfg/n4/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 4
 # my local ip address

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -75,7 +75,22 @@ target_link_options(server PUBLIC -rdynamic)
 set_target_properties(server PROPERTIES OUTPUT_NAME cascade_server)
 add_custom_command(TARGET server POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_CURRENT_SOURCE_DIR}/cfg
-    ${CMAKE_CURRENT_BINARY_DIR}/cfg
+                                               ${CMAKE_CURRENT_BINARY_DIR}/cfg
+    COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/cfg/layout.json
+                   ${CMAKE_CURRENT_BINARY_DIR}/cfg/n0/layout.json
+    COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/cfg/layout.json
+                   ${CMAKE_CURRENT_BINARY_DIR}/cfg/n1/layout.json
+    COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/cfg/layout.json
+                   ${CMAKE_CURRENT_BINARY_DIR}/cfg/n2/layout.json
+    COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/cfg/layout.json
+                   ${CMAKE_CURRENT_BINARY_DIR}/cfg/n3/layout.json
+    COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/cfg/layout.json
+                   ${CMAKE_CURRENT_BINARY_DIR}/cfg/n4/layout.json
+    COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/cfg/layout.json
+                   ${CMAKE_CURRENT_BINARY_DIR}/cfg/n5/layout.json
+    COMMAND ln -sf ${CMAKE_CURRENT_BINARY_DIR}/cfg/layout.json
+                   ${CMAKE_CURRENT_BINARY_DIR}/cfg/n6/layout.json
+    COMMENT "prepare configuration"
 )
 
 add_executable(client client.cpp perftest.cpp)

--- a/src/service/cfg/layout.json
+++ b/src/service/cfg/layout.json
@@ -1,0 +1,50 @@
+[
+    {
+        "type_alias":   "CascadeMetadataService",
+        "layout":       [
+                            {
+                                "min_nodes_by_shard": ["1"],
+                                "max_nodes_by_shard": ["1"],
+                                "delivery_modes_by_shard": ["Ordered"],
+                                "reserved_node_ids_by_shard": [["0"]],
+                                "profiles_by_shard": ["DEFAULT"]
+                            }
+                        ]
+    },
+    {
+        "type_alias":   "VolatileCascadeStoreWithStringKey",
+        "layout":       [
+                            {
+                                "min_nodes_by_shard": ["1"],
+                                "max_nodes_by_shard": ["3"],
+                                "delivery_modes_by_shard": ["Ordered"],
+                                "reserved_node_ids_by_shard": [["1","2","3"]],
+                                "profiles_by_shard": ["DEFAULT"]
+                            }
+                        ]
+    },
+    {
+        "type_alias":   "PersistentCascadeStoreWithStringKey",
+        "layout":       [
+                            {
+                                "min_nodes_by_shard": ["1"],
+                                "max_nodes_by_shard": ["3"],
+                                "delivery_modes_by_shard": ["Ordered"],
+                                "reserved_node_ids_by_shard": [["0"]],
+                                "profiles_by_shard": ["DEFAULT"]
+                            }
+                        ]
+    },
+    {
+        "type_alias":   "TriggerCascadeNoStoreWithStringKey",
+        "layout":       [
+                            {
+                                "min_nodes_by_shard": ["1"],
+                                "max_nodes_by_shard": ["3"],
+                                "delivery_modes_by_shard": ["Ordered"],
+                                "reserved_node_ids_by_shard": [["0"]],
+                                "profiles_by_shard": ["DEFAULT"]
+                            }
+                        ]
+    }
+]'

--- a/src/service/cfg/n0/derecho.cfg
+++ b/src/service/cfg/n0/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 0
 # my local ip address
@@ -167,63 +165,10 @@ default_log_name = derecho_debug
 # default log level
 # Available options:
 # trace,debug,info,warn,error,critical,off
-default_log_level = trace
-
+default_log_level = off
 
 [LAYOUT]
-json_layout = '
-[
-    {
-        "type_alias":   "CascadeMetadataService",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "VolatileCascadeStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "PersistentCascadeStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1","1"],
-                                "max_nodes_by_shard": ["1","1"],
-                                "delivery_modes_by_shard": ["Ordered","Ordered"],
-                                "profiles_by_shard": ["DEFAULT","DEFAULT"]
-                            },
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "TriggerCascadeNoStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    }
-]'
+json_layout_file = 'layout.json'
 
 # cascade service configuration
 # TODO: add document for how to setup a cascade service.

--- a/src/service/cfg/n1/derecho.cfg
+++ b/src/service/cfg/n1/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 1
 # my local ip address
@@ -167,62 +165,10 @@ default_log_name = derecho_debug
 # default log level
 # Available options:
 # trace,debug,info,warn,error,critical,off
-default_log_level = trace
+default_log_level = off
 
 [LAYOUT]
-json_layout = '
-[
-    {
-        "type_alias":   "CascadeMetadataService",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "VolatileCascadeStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "PersistentCascadeStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1","1"],
-                                "max_nodes_by_shard": ["1","1"],
-                                "delivery_modes_by_shard": ["Ordered","Ordered"],
-                                "profiles_by_shard": ["DEFAULT","DEFAULT"]
-                            },
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "TriggerCascadeNoStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    }
-]'
+json_layout_file = 'layout.json'
 
 # cascade service configuration
 # TODO: add document for how to setup a cascade service.

--- a/src/service/cfg/n2/derecho.cfg
+++ b/src/service/cfg/n2/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 2
 # my local ip address
@@ -167,62 +165,10 @@ default_log_name = derecho_debug
 # default log level
 # Available options:
 # trace,debug,info,warn,error,critical,off
-default_log_level = trace
+default_log_level = off
 
 [LAYOUT]
-json_layout = '
-[
-    {
-        "type_alias":   "CascadeMetadataService",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "VolatileCascadeStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "PersistentCascadeStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1","1"],
-                                "max_nodes_by_shard": ["1","1"],
-                                "delivery_modes_by_shard": ["Ordered","Ordered"],
-                                "profiles_by_shard": ["DEFAULT","DEFAULT"]
-                            },
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "TriggerCascadeNoStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    }
-]'
+json_layout_file = 'layout.json'
 
 # cascade service configuration
 # TODO: add document for how to setup a cascade service.

--- a/src/service/cfg/n3/derecho.cfg
+++ b/src/service/cfg/n3/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 3
 # my local ip address
@@ -167,62 +165,10 @@ default_log_name = derecho_debug
 # default log level
 # Available options:
 # trace,debug,info,warn,error,critical,off
-default_log_level = trace
+default_log_level = off
 
 [LAYOUT]
-json_layout = '
-[
-    {
-        "type_alias":   "CascadeMetadataService",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "VolatileCascadeStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "PersistentCascadeStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1","1"],
-                                "max_nodes_by_shard": ["1","1"],
-                                "delivery_modes_by_shard": ["Ordered","Ordered"],
-                                "profiles_by_shard": ["DEFAULT","DEFAULT"]
-                            },
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "TriggerCascadeNoStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    }
-]'
+json_layout_file = 'layout.json'
 
 # cascade service configuration
 # TODO: add document for how to setup a cascade service.

--- a/src/service/cfg/n4/derecho.cfg
+++ b/src/service/cfg/n4/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 4
 # my local ip address
@@ -167,62 +165,10 @@ default_log_name = derecho_debug
 # default log level
 # Available options:
 # trace,debug,info,warn,error,critical,off
-default_log_level = trace
+default_log_level = off
 
 [LAYOUT]
-json_layout = '
-[
-    {
-        "type_alias":   "CascadeMetadataService",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "VolatileCascadeStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "PersistentCascadeStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1","1"],
-                                "max_nodes_by_shard": ["1","1"],
-                                "delivery_modes_by_shard": ["Ordered","Ordered"],
-                                "profiles_by_shard": ["DEFAULT","DEFAULT"]
-                            },
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "TriggerCascadeNoStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    }
-]'
+json_layout_file = 'layout.json'
 
 # cascade service configuration
 # TODO: add document for how to setup a cascade service.

--- a/src/service/cfg/n5/derecho.cfg
+++ b/src/service/cfg/n5/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 5
 # my local ip address
@@ -167,62 +165,10 @@ default_log_name = derecho_debug
 # default log level
 # Available options:
 # trace,debug,info,warn,error,critical,off
-default_log_level = trace
+default_log_level = off
 
 [LAYOUT]
-json_layout = '
-[
-    {
-        "type_alias":   "CascadeMetadataService",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "VolatileCascadeStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "PersistentCascadeStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1","1"],
-                                "max_nodes_by_shard": ["1","1"],
-                                "delivery_modes_by_shard": ["Ordered","Ordered"],
-                                "profiles_by_shard": ["DEFAULT","DEFAULT"]
-                            },
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "TriggerCascadeNoStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    }
-]'
+json_layout_file = 'layout.json'
 
 # cascade service configuration
 # TODO: add document for how to setup a cascade service.

--- a/src/service/cfg/n6/derecho.cfg
+++ b/src/service/cfg/n6/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 6
 # my local ip address
@@ -170,59 +168,7 @@ default_log_name = derecho_debug
 default_log_level = off
 
 [LAYOUT]
-json_layout = '
-[
-    {
-        "type_alias":   "CascadeMetadataService",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "VolatileCascadeStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "PersistentCascadeStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1","1"],
-                                "max_nodes_by_shard": ["1","1"],
-                                "delivery_modes_by_shard": ["Ordered","Ordered"],
-                                "profiles_by_shard": ["DEFAULT","DEFAULT"]
-                            },
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    },
-    {
-        "type_alias":   "TriggerCascadeNoStoreWithStringKey",
-        "layout":       [
-                            {
-                                "min_nodes_by_shard": ["1"],
-                                "max_nodes_by_shard": ["1"],
-                                "delivery_modes_by_shard": ["Ordered"],
-                                "profiles_by_shard": ["DEFAULT"]
-                            }
-                        ]
-    }
-]'
+json_layout_file = 'layout.json'
 
 # cascade service configuration
 # TODO: add document for how to setup a cascade service.

--- a/src/service/sample-derecho.cfg
+++ b/src/service/sample-derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
-# leader ip - the leader's ip address
-leader_ip = 127.0.0.1
-# leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+# contact ip - the current leader's ip address
+contact_ip = 127.0.0.1
+# contact port - the current leader's gms port
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 0
 # my local ip address

--- a/src/udl_zoo/csharp/cfg/n0/derecho.cfg
+++ b/src/udl_zoo/csharp/cfg/n0/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 0
 # my local ip address

--- a/src/udl_zoo/csharp/cfg/n1/derecho.cfg
+++ b/src/udl_zoo/csharp/cfg/n1/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 1
 # my local ip address

--- a/src/udl_zoo/csharp/cfg/n2/derecho.cfg
+++ b/src/udl_zoo/csharp/cfg/n2/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 2
 # my local ip address

--- a/src/udl_zoo/csharp/examples/console_printer/cfg/n0/derecho.cfg
+++ b/src/udl_zoo/csharp/examples/console_printer/cfg/n0/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 0
 # my local ip address

--- a/src/udl_zoo/csharp/examples/console_printer/cfg/n1/derecho.cfg
+++ b/src/udl_zoo/csharp/examples/console_printer/cfg/n1/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 1
 # my local ip address

--- a/src/udl_zoo/csharp/examples/console_printer/cfg/n2/derecho.cfg
+++ b/src/udl_zoo/csharp/examples/console_printer/cfg/n2/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 2
 # my local ip address

--- a/src/udl_zoo/csharp/examples/cosmosdb/cfg/n0/derecho.cfg
+++ b/src/udl_zoo/csharp/examples/cosmosdb/cfg/n0/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 0
 # my local ip address

--- a/src/udl_zoo/csharp/examples/cosmosdb/cfg/n1/derecho.cfg
+++ b/src/udl_zoo/csharp/examples/cosmosdb/cfg/n1/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 1
 # my local ip address

--- a/src/udl_zoo/csharp/examples/cosmosdb/cfg/n2/derecho.cfg
+++ b/src/udl_zoo/csharp/examples/cosmosdb/cfg/n2/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 2
 # my local ip address

--- a/src/udl_zoo/csharp/examples/word_count/cfg/n0/derecho.cfg
+++ b/src/udl_zoo/csharp/examples/word_count/cfg/n0/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 0
 # my local ip address

--- a/src/udl_zoo/csharp/examples/word_count/cfg/n1/derecho.cfg
+++ b/src/udl_zoo/csharp/examples/word_count/cfg/n1/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 1
 # my local ip address

--- a/src/udl_zoo/csharp/examples/word_count/cfg/n2/derecho.cfg
+++ b/src/udl_zoo/csharp/examples/word_count/cfg/n2/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 2
 # my local ip address

--- a/src/udl_zoo/python/cfg/n0/derecho.cfg
+++ b/src/udl_zoo/python/cfg/n0/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 0
 # my local ip address

--- a/src/udl_zoo/python/cfg/n1/derecho.cfg
+++ b/src/udl_zoo/python/cfg/n1/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 1
 # my local ip address

--- a/src/udl_zoo/python/cfg/n2/derecho.cfg
+++ b/src/udl_zoo/python/cfg/n2/derecho.cfg
@@ -1,10 +1,8 @@
 [DERECHO]
 # leader ip - the leader's ip address
-leader_ip = 127.0.0.1
+contact_ip = 127.0.0.1
 # leader gms port - the leader's gms port
-leader_gms_port = 23580
-# leader external client port - the leader's 
-leader_external_port = 32645
+contact_port = 23580
 # my local id - each node should have a different id
 local_id = 2
 # my local ip address


### PR DESCRIPTION
Change: "leader_ip" is now called "contact_ip"; "leader_gms_ip" is now "contact_port". And "leader_external_port" is deprecated.