### PR TITLE
Using libwsong time logger and fixing a performance issue for persistent stable get operations.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,8 @@ if ( NOT DEFINED CMAKE_INSTALL_INCLUDEDIR )
     set( CMAKE_INSTALL_INCLUDEDIR include )
 endif ( )
 
+set(ENABLE_MPROC 1)
+
 find_package(mutils REQUIRED)
 if(mutils_FOUND)
     message(STATUS "Found mutils in ${mutils_INCLUDE_DIRS}")
@@ -56,6 +58,9 @@ find_package(nlohmann_json 3.9.1 REQUIRED)
 # provides the import target rpclib::rpc
 find_package(rpclib 2.3.0 REQUIRED)
 
+# detect libwsong library, which is required for the mproc feature
+find_package(libwsong REQUIRED)
+
 # Hyperscan, which isn't packaged correctly and needs a custom Find module
 find_package(Hyperscan REQUIRED)
 if(Hyperscan_FOUND)
@@ -65,10 +70,6 @@ endif()
 # dotnet
 find_program(DOTNET_CMD dotnet)
 
-# detect libwsong library, which is required for the mproc feature
-find_package(libwsong REQUIRED)
-    
-set(ENABLE_MPROC 1)
 
 # Doxygen, optional to generate documentation HTML
 find_package(Doxygen)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,10 +66,9 @@ endif()
 find_program(DOTNET_CMD dotnet)
 
 # detect libwsong library, which is required for the mproc feature
-find_package(libwsong QUIET)
-if (libwsong_FOUND)
-    set(ENABLE_MPROC 1)
-endif()
+find_package(libwsong REQUIRED)
+    
+set(ENABLE_MPROC 1)
 
 # Doxygen, optional to generate documentation HTML
 find_package(Doxygen)
@@ -114,6 +113,7 @@ target_link_libraries(cascade
     mutils::mutils
     OpenSSL::Crypto
     rpclib::rpc
+    libwsong::perf
     ${Hyperscan_LIBRARIES})
 set_target_properties(cascade PROPERTIES
     SOVERSION ${cascade_VERSION}

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ We recommend coordinating with [Weijia Song](mailto:songweijia@gmail.com) if you
 - Readline library v7.0 or newer. On Ubuntu, use `apt install libreadline-dev` to install it.
 - RPC library [rpclib](https://github.com/rpclib/rpclib). For convenience, install it with [this script](scripts/prerequisites/install-rpclib.sh).
 - Intel's regular expression library [Hyperscan](https://github.com/intel/hyperscan). For convenience, install it with [this script](scripts/prerequisites/install-hyperscan.sh). You need to install ragel compiler if you don't have it. On ubuntu, use `apt-get install ragel` to install it.
+- [libwsong](https://github.com/songweijia/libwsong) commit 47c37bc706cc859f8b60ca4d19b0608e28a2e530. For convenience, install it with [this script](scripts/prerequisites/install-libwsong.sh).
 - [libfuse](https://github.com/libfuse) v3.9.3 or newer (Optional for file system API)
 - [boolinq](https://github.com/k06a/boolinq) or newer (Optional for LINQ API)
 - Python 3.8 or newer and [pybind11](https://github.com/pybind/pybind11) (Optional for Python API)

--- a/cascadeConfig.cmake.in
+++ b/cascadeConfig.cmake.in
@@ -6,6 +6,7 @@ find_dependency(spdlog 1.3.1)
 find_dependency(OpenSSL)
 find_dependency(nlohmann_json 3.9.1)
 find_dependency(rpclib)
+find_dependency(libwsong)
 
 set_and_check(cascade_INCLUDE_DIRS "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")
 set(cascade_LIBRARIES "-L@PACKAGE_CMAKE_INSTALL_LIBDIR@ -lcascade")

--- a/include/cascade/detail/debug_util.hpp
+++ b/include/cascade/detail/debug_util.hpp
@@ -67,30 +67,29 @@ void make_workload(uint32_t payload_size, uint32_t num_distinct_objects, const K
 
 #if __cplusplus > 201703L
 // C++ 20
-#define LOG_TIMESTAMP_BY_TAG(t, g, v, ...)                                                      \
-    if constexpr(std::is_base_of<IHasMessageID, std::decay_t<decltype(v)>>::value) {            \
-        TimestampLogger::log(t,                                                                  \
-                                    g->get_my_id(),                                             \
-                                    dynamic_cast<const IHasMessageID*>(&(v))->get_message_id(), \
-                                    get_walltime()                                              \
-                                            __VA_OPT__(, ) __VA_ARGS__);                        \
+#define LOG_TIMESTAMP_BY_TAG(t, g, v, ...)                                              \
+    if constexpr(std::is_base_of<IHasMessageID, std::decay_t<decltype(v)>>::value) {    \
+        TimestampLogger::log(t,                                                         \
+                             g->get_my_id(),                                            \
+                             dynamic_cast<const IHasMessageID*>(&(v))->get_message_id() \
+                             __VA_OPT__(, ) __VA_ARGS__);                               \
     }
 #else
 // C++ 17
-#define LOG_TIMESTAMP_BY_TAG(t, g, v)                                                           \
-    if constexpr(std::is_base_of<IHasMessageID, std::decay_t<decltype(v)>>::value) {            \
-        TimestampLogger::log(t,                                                                  \
-                                    g->get_my_id(),                                             \
-                                    dynamic_cast<const IHasMessageID*>(&(v))->get_message_id(), \
-                                    get_walltime());                                            \
+#define LOG_TIMESTAMP_BY_TAG(t, g, v)                                                   \
+    if constexpr(std::is_base_of<IHasMessageID, std::decay_t<decltype(v)>>::value) {    \
+        TimestampLogger::log(t,                                                         \
+                             g->get_my_id(),                                            \
+                             dynamic_cast<const IHasMessageID*>(&(v))->get_message_id() \
+        );                                                                              \
     }
 
-#define LOG_TIMESTAMP_BY_TAG_EXTRA(t, g, v, e)                                                  \
-    if constexpr(std::is_base_of<IHasMessageID, std::decay_t<decltype(v)>>::value) {            \
-        TimestampLogger::log(t,                                                                  \
-                                    g->get_my_id(),                                             \
-                                    dynamic_cast<const IHasMessageID*>(&(v))->get_message_id(), \
-                                    get_walltime(), e);                                         \
+#define LOG_TIMESTAMP_BY_TAG_EXTRA(t, g, v, e)                                          \
+    if constexpr(std::is_base_of<IHasMessageID, std::decay_t<decltype(v)>>::value) {    \
+        TimestampLogger::log(t,                                                         \
+                             g->get_my_id(),                                            \
+                             dynamic_cast<const IHasMessageID*>(&(v))->get_message_id(),\
+                             e);                                                        \
     }
 
 #endif  //__cplusplus > 201703L

--- a/include/cascade/detail/persistent_store_impl.hpp
+++ b/include/cascade/detail/persistent_store_impl.hpp
@@ -100,7 +100,17 @@ const VT PersistentCascadeStore<KT, VT, IK, IV, ST>::get(const KT& key, const pe
         derecho::Replicated<PersistentCascadeStore>& subgroup_handle = group->template get_subgroup<PersistentCascadeStore>(this->subgroup_index);
         requested_version = ver;
         if(requested_version == CURRENT_VERSION) {
+#if __cplusplus > 201703L
+            LOG_TIMESTAMP_BY_TAG(100001, group,*IV,ver);
+#else
+            LOG_TIMESTAMP_BY_TAG_EXTRA(100001, group,*IV,ver);
+#endif
             requested_version = subgroup_handle.get_global_persistence_frontier();
+#if __cplusplus > 201703L
+            LOG_TIMESTAMP_BY_TAG(100002, group,*IV,ver);
+#else
+            LOG_TIMESTAMP_BY_TAG_EXTRA(100002, group,*IV,ver);
+#endif
         } else {
             // The first condition test if requested_version is beyond the active latest atomic broadcast version.
             // However, that could be true for a valid requested version for a new started setup, where the active

--- a/include/cascade/detail/persistent_store_impl.hpp
+++ b/include/cascade/detail/persistent_store_impl.hpp
@@ -100,17 +100,7 @@ const VT PersistentCascadeStore<KT, VT, IK, IV, ST>::get(const KT& key, const pe
         derecho::Replicated<PersistentCascadeStore>& subgroup_handle = group->template get_subgroup<PersistentCascadeStore>(this->subgroup_index);
         requested_version = ver;
         if(requested_version == CURRENT_VERSION) {
-#if __cplusplus > 201703L
-            LOG_TIMESTAMP_BY_TAG(100001, group,*IV,ver);
-#else
-            LOG_TIMESTAMP_BY_TAG_EXTRA(100001, group,*IV,ver);
-#endif
             requested_version = subgroup_handle.get_global_persistence_frontier();
-#if __cplusplus > 201703L
-            LOG_TIMESTAMP_BY_TAG(100002, group,*IV,ver);
-#else
-            LOG_TIMESTAMP_BY_TAG_EXTRA(100002, group,*IV,ver);
-#endif
         } else {
             // The first condition test if requested_version is beyond the active latest atomic broadcast version.
             // However, that could be true for a valid requested version for a new started setup, where the active

--- a/include/cascade/detail/persistent_store_impl.hpp
+++ b/include/cascade/detail/persistent_store_impl.hpp
@@ -161,23 +161,37 @@ const VT PersistentCascadeStore<KT, VT, IK, IV, ST>::get(const KT& key, const pe
                     return *IV;
                 } else {
                     // fall back to the slow path.
-                    auto versioned_state_ptr = persistent_core.get(requested_version);
-                    if(versioned_state_ptr->kv_map.find(key) != versioned_state_ptr->kv_map.end()) {
+                    // following the backward chain until its version is behine requested_version.
+                    // TODO: We can introduce a per-key version index to achieve a better performance
+                    //       with a 64bit per log entry memory overhead.
+                    VT o = persistent_core->lockless_get(key);
+                    persistent::version_t target_version = o.version;
+                    while (target_version > requested_version) {
+                        target_version = 
+                            persistent_core.template getDelta<VT>(target_version,true,
+                                [](const VT& v){
+                                    return v.previous_version_by_key;
+                                });
+                    }
+                    if (target_version == persistent::INVALID_VERSION) {
 #if __cplusplus > 201703L
                         LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_END, group,*IV,ver);
 #else
                         LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_END, group,*IV,ver);
 #endif
-                        debug_leave_func_with_value("Reconstructed version:0x{:x} for key:{}", requested_version, key);
-                        return versioned_state_ptr->kv_map.at(key);
-                    }
+                        debug_leave_func_with_value("No data found for key:{} before version:0x{:x}", key, requested_version);
+                        return *IV;
+                    } else {
 #if __cplusplus > 201703L
-                    LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_END, group,*IV,ver);
+                        LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_END, group,*IV,ver);
 #else
-                    LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_END, group,*IV,ver);
+                        LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_END, group,*IV,ver);
 #endif
-                    debug_leave_func_with_value("No data found for key:{} before version:0x{:x}", key, requested_version);
-                    return *IV;
+                        return persistent_core.template getDelta<VT>(target_version,true,
+                                [](const VT& v){
+                                    return v;
+                                });
+                    }
                 }
             }
         });

--- a/include/cascade/detail/service_impl.hpp
+++ b/include/cascade/detail/service_impl.hpp
@@ -49,7 +49,7 @@ Service<CascadeTypes...>::Service(const std::vector<DeserializationContext*>& ds
                     nullptr,
                     // persistent
                     [this](subgroup_id_t sgid, persistent::version_t ver){
-                        TimestampLogger::log(TLT_PERSISTED,group->get_my_id(),0,get_walltime(),ver);
+                        TimestampLogger::log(TLT_PERSISTED,group->get_my_id(),0,ver);
                     },
                     nullptr
 #endif
@@ -147,7 +147,7 @@ std::unique_ptr<CascadeType> client_stub_factory() {
 
 #ifdef ENABLE_EVALUATION
 #define LOG_SERVICE_CLIENT_TIMESTAMP(tag,msgid) \
-    TimestampLogger::log(tag,this->get_my_id(),msgid,get_walltime());
+    TimestampLogger::log(tag,this->get_my_id(),msgid);
 #else
 #define LOG_SERVICE_CLIENT_TIMESTAMP(tag,msgid)
 #endif

--- a/include/cascade/service.hpp
+++ b/include/cascade/service.hpp
@@ -205,7 +205,7 @@ namespace cascade {
                 TimestampLogger::log(TLT_ACTION_FIRE_START,
                                      0,
                                      dynamic_cast<const IHasMessageID*>(value_ptr.get())->get_message_id(),
-                                     get_time_ns(), 0);
+                                     0);
                 dbg_default_trace("In {}: [worker_id={}] action is fired.", __PRETTY_FUNCTION__, worker_id);
                 (*ocdpo_ptr)(sender,key_string,prefix_length,version,value_ptr.get(),outputs,ctxt,worker_id);
             }

--- a/scripts/prerequisites/install-libwsong.sh
+++ b/scripts/prerequisites/install-libwsong.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -eU
+export TMPDIR=/var/tmp
+WORKPATH=`mktemp -d`
+INSTALL_PREFIX="/usr/local"
+if [[ $# -gt 0 ]]; then
+    INSTALL_PREFIX=$1
+fi
+
+echo "Using INSTALL_PREFIX=${INSTALL_PREFIX}"
+
+cd ${WORKPATH}
+git clone https://github.com/songweijia/libwsong.git
+cd libwsong
+git checkout 47c37bc706cc859f8b60ca4d19b0608e28a2e530
+mkdir build
+cd build
+cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} ..
+make -j `nproc`
+make install

--- a/src/applications/standalone/dds/src/client.cpp
+++ b/src/applications/standalone/dds/src/client.cpp
@@ -239,7 +239,7 @@ static bool run_perftest(
             }
         }
 #if !defined(USE_DDS_TIMESTAMP_LOG)
-        TimestampLogger::flush(topic+".publisher.log",true);
+        TimestampLogger::flush(topic+".publisher.log");
 #endif
 
     } else {
@@ -265,7 +265,7 @@ static bool run_perftest(
                         // ts_log.emplace_back(std::tuple{msg.seqno,msg.sending_ts_us,get_walltime()/1000});
                         ts_log.emplace_back(std::tuple{header->seqno,header->sending_ts_us,get_walltime()/1000});
 #else
-                        TimestampLogger::log(TLT_DDS_SUBSCRIBER_CALLED,-1,0,get_time_ns(),received);
+                        TimestampLogger::log(TLT_DDS_SUBSCRIBER_CALLED,-1,0,received);
                         received ++;
 #endif
                         // end of test
@@ -299,7 +299,7 @@ static bool run_perftest(
         }
         ofile.close();
 #else
-        TimestampLogger::flush(topic+".subscriber.log",true);
+        TimestampLogger::flush(topic+".subscriber.log");
 #endif
     }
 

--- a/src/applications/tests/pipeline/pipeline_udl.cpp
+++ b/src/applications/tests/pipeline/pipeline_udl.cpp
@@ -38,7 +38,6 @@ class PipelineOCDPO: public OffCriticalDataPathObserver {
         TimestampLogger::log(TLT_PIPELINE(stage),
             typed_ctxt->get_service_client_ref().get_my_id(),
             value->get_message_id(),
-            get_walltime(),
             worker_id+stage*10000);
 #endif//ENABLE_EVALUATION
         for (auto& okv:outputs) {

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -48,7 +48,7 @@ target_include_directories(service PRIVATE
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
-target_link_libraries(service derecho::derecho)
+target_link_libraries(service derecho::derecho libwsong::perf)
 add_dependencies(service udl_signature)
 
 if (ENABLE_MPROC)
@@ -70,7 +70,7 @@ target_include_directories(server PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
 )
-target_link_libraries(server cascade dl pthread)
+target_link_libraries(server cascade dl pthread libwsong::perf)
 target_link_options(server PUBLIC -rdynamic)
 set_target_properties(server PROPERTIES OUTPUT_NAME cascade_server)
 add_custom_command(TARGET server POST_BUILD
@@ -103,7 +103,7 @@ target_include_directories(client PRIVATE
 target_include_directories(client PUBLIC
     $<BUILD_INTERFACE:${Readline_INCLUDE_DIRS}>
 )
-target_link_libraries(client cascade ${Readline_LIBRARIES} pthread)
+target_link_libraries(client cascade ${Readline_LIBRARIES} pthread libwsong::perf)
 if(ENABLE_EVALUATION)
     target_link_libraries(client rpclib::rpc)
 endif()

--- a/src/service/perftest.cpp
+++ b/src/service/perftest.cpp
@@ -132,7 +132,7 @@ bool PerfTestServer::eval_put(uint64_t max_operation_per_second,
             } else {
                 throw derecho_exception{"Evaluation requests an object to support IHasMessageID interface."};
             }
-            TimestampLogger::log(TLT_READY_TO_SEND,this->capi.get_my_id(),message_id,get_walltime());
+            TimestampLogger::log(TLT_READY_TO_SEND,this->capi.get_my_id(),message_id);
             if (subgroup_index == INVALID_SUBGROUP_INDEX ||
                 shard_index == INVALID_SHARD_INDEX) {
                 future_appender(this->capi.put(objects.at(now_ns%num_distinct_objects)));
@@ -142,7 +142,7 @@ bool PerfTestServer::eval_put(uint64_t max_operation_per_second,
                     future_appender,
                     this->capi.template put, objects.at(now_ns%num_distinct_objects), subgroup_index, shard_index);
             }
-            TimestampLogger::log(TLT_EC_SENT,this->capi.get_my_id(),message_id,get_walltime());
+            TimestampLogger::log(TLT_EC_SENT,this->capi.get_my_id(),message_id);
             message_id ++;
         }
         // wait for all pending futures.
@@ -179,7 +179,7 @@ bool PerfTestServer::eval_put_and_forget(uint64_t max_operation_per_second,
             throw derecho_exception{"Evaluation requests an object to support IHasMessageID interface."};
         }
         // log time.
-        TimestampLogger::log(TLT_READY_TO_SEND,this->capi.get_my_id(),message_id,get_walltime());
+        TimestampLogger::log(TLT_READY_TO_SEND,this->capi.get_my_id(),message_id);
         // send it
         if (subgroup_index == INVALID_SUBGROUP_INDEX || shard_index == INVALID_SHARD_INDEX) {
             this->capi.put_and_forget(objects.at(now_ns%num_distinct_objects));
@@ -188,7 +188,7 @@ bool PerfTestServer::eval_put_and_forget(uint64_t max_operation_per_second,
                     this->capi.template put_and_forget, objects.at(now_ns%num_distinct_objects), subgroup_index, shard_index);
         }
         // log time.
-        TimestampLogger::log(TLT_EC_SENT,this->capi.get_my_id(),message_id,get_walltime());
+        TimestampLogger::log(TLT_EC_SENT,this->capi.get_my_id(),message_id);
         message_id ++;
     }
     return true;
@@ -223,14 +223,14 @@ bool PerfTestServer::eval_trigger_put(uint64_t max_operation_per_second,
             throw derecho_exception{"Evaluation requests an object to support IHasMessageID interface."};
         }
         // log time.
-        TimestampLogger::log(TLT_READY_TO_SEND,this->capi.get_my_id(),message_id,get_walltime());
+        TimestampLogger::log(TLT_READY_TO_SEND,this->capi.get_my_id(),message_id);
         if (subgroup_index == INVALID_SUBGROUP_INDEX || shard_index == INVALID_SHARD_INDEX) {
             this->capi.trigger_put(objects.at(now_ns%num_distinct_objects));
         } else {
             on_subgroup_type_index(std::decay_t<decltype(capi)>::subgroup_type_order.at(subgroup_type_index),
                     this->capi.template trigger_put, objects.at(now_ns%num_distinct_objects), subgroup_index, shard_index);
         }
-        TimestampLogger::log(TLT_EC_SENT,this->capi.get_my_id(),message_id,get_walltime());
+        TimestampLogger::log(TLT_EC_SENT,this->capi.get_my_id(),message_id);
         message_id ++;
     }
 
@@ -283,7 +283,7 @@ bool PerfTestServer::eval_get(int32_t log_depth,
                         for(auto& reply : replies) {
                             reply.second.get();
                             // This might not be an accurate time for when the query completed, depending on how long the thread waited to acquire the queue lock
-                            TimestampLogger::log(TLT_EC_GET_FINISHED, my_node_id, message_id, get_walltime());
+                            TimestampLogger::log(TLT_EC_GET_FINISHED, my_node_id, message_id);
                             break;
                         }
                         pending_futures.pop();
@@ -377,7 +377,7 @@ bool PerfTestServer::eval_get(int32_t log_depth,
                 };
         std::size_t cur_object_index = now_ns % num_distinct_objects;
         // NOTE: Setting the message ID on the object won't do anything because we're doing a Get, not a Put
-        TimestampLogger::log(TLT_READY_TO_SEND, my_node_id, message_id, get_walltime());
+        TimestampLogger::log(TLT_READY_TO_SEND, my_node_id, message_id);
         // With either the object pool interface or the shard interface, further decide whether to request the current version or an old version
         if(subgroup_index == INVALID_SUBGROUP_INDEX || shard_index == INVALID_SHARD_INDEX) {
             if(log_depth == -1) {
@@ -405,7 +405,7 @@ bool PerfTestServer::eval_get(int32_t log_depth,
                         this->capi.template get, objects.at(cur_object_index).get_key_ref(), oldest_object_versions.at(cur_object_index), true, subgroup_index, shard_index);
             }
         }
-        TimestampLogger::log(TLT_EC_SENT, my_node_id, message_id, get_walltime());
+        TimestampLogger::log(TLT_EC_SENT, my_node_id, message_id);
         message_id++;
     }
     dbg_default_info("eval_get: All messages sent, waiting for queries to complete");
@@ -459,7 +459,7 @@ bool PerfTestServer::eval_get_by_time(uint64_t ms_in_past,
                         // Get only the first reply
                         for(auto& reply : replies) {
                             reply.second.get();
-                            TimestampLogger::log(TLT_EC_GET_FINISHED, my_node_id, message_id, get_walltime());
+                            TimestampLogger::log(TLT_EC_GET_FINISHED, my_node_id, message_id);
                             break;
                         }
                         pending_futures.pop();
@@ -597,7 +597,7 @@ bool PerfTestServer::eval_get_by_time(uint64_t ms_in_past,
                     futures_cv.notify_one();
                 };
         // NOTE: Setting the message ID on the object won't do anything because we're doing a Get, not a Put
-        TimestampLogger::log(TLT_READY_TO_SEND, my_node_id, message_id, get_walltime());
+        TimestampLogger::log(TLT_READY_TO_SEND, my_node_id, message_id);
         if(subgroup_index == INVALID_SUBGROUP_INDEX || shard_index == INVALID_SHARD_INDEX) {
             future_appender(this->capi.get_by_time(objects.at(object_to_request).get_key_ref(), timestamp_to_request));
         } else {
@@ -606,7 +606,7 @@ bool PerfTestServer::eval_get_by_time(uint64_t ms_in_past,
                     future_appender,
                     this->capi.template get_by_time, objects.at(object_to_request).get_key_ref(), timestamp_to_request, true, subgroup_index, shard_index);
         }
-        TimestampLogger::log(TLT_EC_SENT, my_node_id, message_id, get_walltime());
+        TimestampLogger::log(TLT_EC_SENT, my_node_id, message_id);
         message_id++;
     }
     dbg_default_info("eval_get: All messages sent, waiting for queries to complete");

--- a/src/service/python/cascade_client.py
+++ b/src/service/python/cascade_client.py
@@ -775,7 +775,7 @@ class CascadeClientShell(cmd.Cmd):
             if len(args) < 2:
                 print(bcolors.FAIL + 'No filename is given.' + bcolors.RESET)
                 return
-            tl.flush(args[1],True)
+            tl.flush(args[1])
         else:
             print(bcolors.FAIL + f"Unknown timestamp_logger command: {cmd}." + bcolors.RESET)
 

--- a/src/service/python/cascade_client_py.cpp
+++ b/src/service/python/cascade_client_py.cpp
@@ -1155,34 +1155,21 @@ PYBIND11_MODULE(member_client, m) {
                 }
             )
         .def(
-                "log", [](TimestampLogger_PythonWrapper&, uint64_t tag, uint64_t node_id, uint64_t msg_id, uint64_t ts_ns, uint64_t extra) {
-                    TimestampLogger::log(tag,node_id,msg_id,ts_ns,extra);
+                "log", [](TimestampLogger_PythonWrapper&, uint64_t tag, uint64_t node_id, uint64_t msg_id, uint64_t extra) {
+                    TimestampLogger::log(tag,node_id,msg_id,extra);
                 },
                 "Log given timestamp. \n"
-                "\t@arg0    tag, an uint64_t number defined in <include>/cascade/utils.hpp.\n"
-                "\t@arg1    node_id, the id of local node.\n"
-                "\t@arg2    msg_id, the message id of this log.\n"
-                "\t@arg3    ts_ns, the timestamp in nano seconds.\n"
-                "\t@arg4    extra, the extra information you want to add."
-            )
-        .def(
-                "log", [](TimestampLogger_PythonWrapper&, uint64_t tag, uint64_t node_id, uint64_t msg_id, uint64_t extra) {
-                    uint64_t ts_ns = get_time_ns();
-                    TimestampLogger::log(tag,node_id,msg_id,ts_ns,extra);
-                },
-                "Log current timestamp. \n"
                 "\t@arg0    tag, an uint64_t number defined in <include>/cascade/utils.hpp.\n"
                 "\t@arg1    node_id, the id of local node.\n"
                 "\t@arg2    msg_id, the message id of this log.\n"
                 "\t@arg3    extra, the extra information you want to add."
             )
         .def(
-                "flush", [](TimestampLogger_PythonWrapper&, const std::string& filename, bool clear) {
-                    TimestampLogger::flush(filename,clear);
+                "flush", [](TimestampLogger_PythonWrapper&, const std::string& filename) {
+                    TimestampLogger::flush(filename);
                 },
                 "Flush timestamp log to file. \n"
-                "\t@arg0    filename, the filename\n"
-                "\t@arg1    clear, if True, the timestamp log in memory will be cleared. otherwise, we keep it."
+                "\t@arg0    filename, the filename."
             )
         .def(
                 "clear", [](TimestampLogger_PythonWrapper&) {

--- a/src/service/server.hpp
+++ b/src/service/server.hpp
@@ -146,13 +146,11 @@ class CascadeServiceCDPO : public CriticalDataPathObserver<CascadeType> {
                         TimestampLogger::log(TLT_ACTION_POST_START,
                                              engine->get_service_client_ref().get_my_id(),
                                              dynamic_cast<const IHasMessageID*>(&value)->get_message_id(),
-                                             get_time_ns(),
                                              apei.uint64_val);
                         engine->post(std::move(action), oi.statefulness, is_trigger);
                         TimestampLogger::log(TLT_ACTION_POST_END,
                                              engine->get_service_client_ref().get_my_id(),
                                              dynamic_cast<const IHasMessageID*>(&value)->get_message_id(),
-                                             get_time_ns(),
                                              apei.uint64_val);
                     }
                 }

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -195,39 +195,12 @@ TimestampLogger::TimestampLogger() {
             this->tag_enabler.emplace(std::stoul(s));
         }
     }
-    pthread_spin_init(&lck,PTHREAD_PROCESS_PRIVATE);
-    _log.reserve(65536);
 }
 
-void TimestampLogger::instance_log(uint64_t tag, uint64_t node_id, uint64_t msg_id, uint64_t ts_ns, uint64_t extra) {
+void TimestampLogger::instance_log(uint64_t tag, uint64_t node_id, uint64_t msg_id, uint64_t extra) {
     if (tag_enabler.find(tag) != tag_enabler.cend()) {
-        pthread_spin_lock(&lck);
-        _log.emplace_back(tag,node_id,msg_id,ts_ns,extra);
-        pthread_spin_unlock(&lck);
+        ws_timing_punch(tag,node_id,msg_id,extra,0ull);
     }
-}
-
-void TimestampLogger::instance_flush(const std::string& filename, bool clear) {
-    pthread_spin_lock(&lck);
-    std::ofstream outfile(filename);
-    for (auto& ent: this->_log) {
-        outfile << std::get<0>(ent) << " "
-                << std::get<1>(ent) << " "
-                << std::get<2>(ent) << " "
-                << std::get<3>(ent) << " "
-                << std::get<4>(ent) << std::endl;
-    }
-    outfile.close();
-    if (clear) {
-        _log.clear();
-    }
-    pthread_spin_unlock(&lck);
-}
-
-void TimestampLogger::instance_clear() {
-    pthread_spin_lock(&lck);
-    _log.clear();
-    pthread_spin_unlock(&lck);
 }
 
 TimestampLogger TimestampLogger::_tl{};


### PR DESCRIPTION
There are two major changes in this pull request.

1. Instead of using Cascade's own timestamp logger, this pull request shifts to [wsong::perf timestamp logger](https://github.com/songweijia/libwsong/blob/main/include/wsong/perf/timing.h). This facilitates performance tuning/debugging with the underlying library Derecho and external components.

2. When using persistent get with the stable flag, it will fall back to persistent<T>.get(), which reconstructs the full state of the request version from the start of the log. That is way too expensive. In this pull request, this is optimized by leveraging the per-key backward chain and searching back starting from the current state. TODO: Although this is much faster than persistent<T>::get(), an even faster approach is a per-key index with a little memory overhead.
