### PR TITLE
Log entry data is now a vector, get previous versions should be aware of that.

### DIFF
--- a/include/cascade/cascade_interface.hpp
+++ b/include/cascade/cascade_interface.hpp
@@ -231,6 +231,10 @@ public:
      * Get the status of a given transaction.
      *
      * @param[in]   txid    ID of the transaction
+     * @param[in]   stable
+     *              If `stable == false`, we only return the data reflecting the latest locally delivered atomic
+     *              broadcast. Otherwise, stable data will be returned, meaning that the persisted states returned
+     *              is safe: they will survive after whole system recovery.
      *
      * @return      Status of the transaction
      */

--- a/include/cascade/detail/persistent_store_impl.hpp
+++ b/include/cascade/detail/persistent_store_impl.hpp
@@ -176,58 +176,70 @@ const VT PersistentCascadeStore<KT, VT, IK, IV, ST>::get(const KT& key, const pe
 #endif
         return persistent_core->lockless_get(key);
     } else {
-        return persistent_core.template getDelta<VT>(requested_version, exact, [this, key, requested_version, exact, ver](const VT& v) {
-            if(key == v.get_key_ref()) {
-                debug_leave_func_with_value("key:{} is found at version:0x{:x}", key, requested_version);
-#if __cplusplus > 201703L
-                LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_END, group,*IV,ver);
-#else
-                LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_END, group,*IV,ver);
-#endif
-                return v;
-            } else {
-                if(exact) {
-                    // return invalid object for EXACT search.
-                    debug_leave_func_with_value("No data found for key:{} at version:0x{:x}", key, requested_version);
+        return persistent_core.template getDelta<std::vector<VT>>(requested_version, exact, [this, key, requested_version, exact, ver](const std::vector<VT>& vv) {
+            for (const auto& v:vv) {
+                if(key == v.get_key_ref()) {
+                    debug_leave_func_with_value("key:{} is found at version:0x{:x}", key, requested_version);
 #if __cplusplus > 201703L
                     LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_END, group,*IV,ver);
 #else
                     LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_END, group,*IV,ver);
 #endif
+                    return v;
+                }
+            }
+
+            if(exact) {
+                // return invalid object for EXACT search.
+                debug_leave_func_with_value("No data found for key:{} at version:0x{:x}", key, requested_version);
+#if __cplusplus > 201703L
+                LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_END, group,*IV,ver);
+#else
+                LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_END, group,*IV,ver);
+#endif
+                return *IV;
+            } else {
+                // fall back to the slow path.
+                // following the backward chain until its version is behine requested_version.
+                // TODO: We can introduce a per-key version index to achieve a better performance
+                //       with a 64bit per log entry memory overhead.
+                VT o = persistent_core->lockless_get(key);
+                persistent::version_t target_version = o.version;
+                while (target_version > requested_version) {
+                    target_version = 
+                        persistent_core.template getDelta<std::vector<VT>>(target_version,true,
+                            [&key](const std::vector<VT>& vv){
+                                for (const auto& v:vv) {
+                                    if (key == v.get_key_ref()) {
+                                        return v.previous_version_by_key;
+                                    }
+                                }
+                                return persistent::INVALID_VERSION;
+                            });
+                }
+                if (target_version == persistent::INVALID_VERSION) {
+#if __cplusplus > 201703L
+                    LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_END, group,*IV,ver);
+#else
+                    LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_END, group,*IV,ver);
+#endif
+                    debug_leave_func_with_value("No data found for key:{} before version:0x{:x}", key, requested_version);
                     return *IV;
                 } else {
-                    // fall back to the slow path.
-                    // following the backward chain until its version is behine requested_version.
-                    // TODO: We can introduce a per-key version index to achieve a better performance
-                    //       with a 64bit per log entry memory overhead.
-                    VT o = persistent_core->lockless_get(key);
-                    persistent::version_t target_version = o.version;
-                    while (target_version > requested_version) {
-                        target_version = 
-                            persistent_core.template getDelta<VT>(target_version,true,
-                                [](const VT& v){
-                                    return v.previous_version_by_key;
-                                });
-                    }
-                    if (target_version == persistent::INVALID_VERSION) {
 #if __cplusplus > 201703L
-                        LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_END, group,*IV,ver);
+                    LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_END, group,*IV,ver);
 #else
-                        LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_END, group,*IV,ver);
+                    LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_END, group,*IV,ver);
 #endif
-                        debug_leave_func_with_value("No data found for key:{} before version:0x{:x}", key, requested_version);
-                        return *IV;
-                    } else {
-#if __cplusplus > 201703L
-                        LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_END, group,*IV,ver);
-#else
-                        LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_END, group,*IV,ver);
-#endif
-                        return persistent_core.template getDelta<VT>(target_version,true,
-                                [](const VT& v){
-                                    return v;
-                                });
-                    }
+                    return persistent_core.template getDelta<std::vector<VT>>(target_version,true,
+                            [&key](const std::vector<VT>& vv){
+                                for (const auto& v:vv) {
+                                    if (key == v.get_key_ref()) {
+                                        return v;
+                                    }
+                                }
+                                return *IV;
+                            });
                 }
             }
         });
@@ -447,47 +459,49 @@ uint64_t PersistentCascadeStore<KT, VT, IK, IV, ST>::get_size(const KT& key, con
 #endif
          return rvo_val;
     } else {
-        return persistent_core.template getDelta<VT>(requested_version, exact, [this, key, requested_version, exact, ver](const VT& v) -> uint64_t {
-            if(key == v.get_key_ref()) {
-                debug_leave_func_with_value("key:{} is found at version:0x{:x}", key, requested_version);
-                uint64_t size = mutils::bytes_size(v);
+        return persistent_core.template getDelta<std::vector<VT>>(requested_version, exact, [this, key, requested_version, exact, ver](const std::vector<VT>& vv) -> uint64_t {
+            for (const auto& v: vv) {
+                if(key == v.get_key_ref()) {
+                    debug_leave_func_with_value("key:{} is found at version:0x{:x}", key, requested_version);
+                    uint64_t size = mutils::bytes_size(v);
+#if __cplusplus > 201703L
+                    LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_SIZE_END, group,*IV,ver);
+#else
+                    LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_SIZE_END, group,*IV,ver);
+#endif
+                    return size;
+                }
+            }
+
+            if(exact) {
+                // return invalid object for EXACT search.
+                debug_leave_func_with_value("No data found for key:{} at version:0x{:x}", key, requested_version);
 #if __cplusplus > 201703L
                 LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_SIZE_END, group,*IV,ver);
 #else
                 LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_SIZE_END, group,*IV,ver);
 #endif
-                return size;
+                return 0ull;
             } else {
-                if(exact) {
-                    // return invalid object for EXACT search.
-                    debug_leave_func_with_value("No data found for key:{} at version:0x{:x}", key, requested_version);
+                // fall back to the slow path.
+                auto versioned_state_ptr = persistent_core.get(requested_version);
+                if(versioned_state_ptr->kv_map.find(key) != versioned_state_ptr->kv_map.end()) {
+                    debug_leave_func_with_value("Reconstructed version:0x{:x} for key:{}", requested_version, key);
+                    uint64_t size = mutils::bytes_size(versioned_state_ptr->kv_map.at(key));
 #if __cplusplus > 201703L
                     LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_SIZE_END, group,*IV,ver);
 #else
                     LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_SIZE_END, group,*IV,ver);
 #endif
-                    return 0ull;
-                } else {
-                    // fall back to the slow path.
-                    auto versioned_state_ptr = persistent_core.get(requested_version);
-                    if(versioned_state_ptr->kv_map.find(key) != versioned_state_ptr->kv_map.end()) {
-                        debug_leave_func_with_value("Reconstructed version:0x{:x} for key:{}", requested_version, key);
-                        uint64_t size = mutils::bytes_size(versioned_state_ptr->kv_map.at(key));
-#if __cplusplus > 201703L
-                        LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_SIZE_END, group,*IV,ver);
-#else
-                        LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_SIZE_END, group,*IV,ver);
-#endif
-                        return size;
-                    }
-                    debug_leave_func_with_value("No data found for key:{} before version:0x{:x}", key, requested_version);
-#if __cplusplus > 201703L
-                    LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_SIZE_END, group,*IV,ver);
-#else
-                    LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_SIZE_END, group,*IV,ver);
-#endif
-                    return 0ull;
+                    return size;
                 }
+                debug_leave_func_with_value("No data found for key:{} before version:0x{:x}", key, requested_version);
+#if __cplusplus > 201703L
+                LOG_TIMESTAMP_BY_TAG(TLT_PERSISTENT_GET_SIZE_END, group,*IV,ver);
+#else
+                LOG_TIMESTAMP_BY_TAG_EXTRA(TLT_PERSISTENT_GET_SIZE_END, group,*IV,ver);
+#endif
+                return 0ull;
             }
         });
     }

--- a/include/cascade/service.hpp
+++ b/include/cascade/service.hpp
@@ -714,8 +714,6 @@ namespace cascade {
          *                                        has seen. Cascade will reject the write if the corresponding key has been updated
          *                                        already. TODO: should we make it an optional feature?
          * @param[in] mapped_readonly_objects   a map between subgroup/shard index and a list of objects in the corresponding shard that must match versions
-         * @param[in] subgroup_index            the subgroup index of CascadeType
-         * @param[in] shard_index               the shard index that will first receive the transaction
          *
          * @return a future to the transaction id and current status
          */
@@ -753,10 +751,17 @@ namespace cascade {
          * "type_recursive_put_objects" is a helper function for internal use only.
          * @param[in]   type_index  the index of the subgroup type in the CascadeTypes... list. And the FirstType,
          *                          SecondType, ..., RestTypes should be in the same order.
-         * @param[in]   objects      the list of objects to write
-         * @param[in]   subgroup_index
-         *                          the subgroup index in the subgroup type designated by type_index
-         * @param[in]   shard_index the shard index
+         * @param[in] mapped_objects            a map between subgroup/shard index and a list of objects to write in the corresponding shard.
+         *                                      User provided SubgroupType::ObjectType must have the following two members:
+         *                                      - SubgroupType::ObjectType::key of SubgroupType::KeyType, which must be set to a
+         *                                        valid key.
+         *                                      - SubgroupType::ObjectType::ver of std::tuple<persistent::version_t, uint64_t>.
+         *                                        Similar to the return object, this member is a two tuple with the first member
+         *                                        for a version and the second for a timestamp. A caller of put can specify either
+         *                                        of the version and timestamp meaning what is the latest version/timestamp the caller
+         *                                        has seen. Cascade will reject the write if the corresponding key has been updated
+         *                                        already. TODO: should we make it an optional feature?
+         * @param[in] mapped_readonly_objects   a map between subgroup/shard index and a list of objects in the corresponding shard that must match versions
          *
          * @return a future to the version and timestamp of the put operation.
          */


### PR DESCRIPTION
`PersistentCascadeStore::get()` is now adapted to vectorized delta. The slow path is also accelerated using per-key backward versions.

Regression tested with `cascade_api_test` case.

To @tgarr, do you think using `unordered_map` is a better choice for `vector` in the delta, because the map facilitate O(1) search for the key?