### PR TITLE
Fixed a missing dependency in CMakeLists for mproc_manager

### DIFF
--- a/scripts/prerequisites/install-hyperscan.sh
+++ b/scripts/prerequisites/install-hyperscan.sh
@@ -18,3 +18,4 @@ cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} ..
 make -j `nproc`
 make install
+rm -rf ${WORKPATH}

--- a/scripts/prerequisites/install-libwsong.sh
+++ b/scripts/prerequisites/install-libwsong.sh
@@ -18,3 +18,4 @@ cd build
 cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} ..
 make -j `nproc`
 make install
+rm -rf ${WORKPATH}

--- a/scripts/prerequisites/install-rpclib.sh
+++ b/scripts/prerequisites/install-rpclib.sh
@@ -20,3 +20,4 @@ cd build
 cmake -DCMAKE_INSTALL_PREFIX=${INSTALL_PREFIX} ..
 make -j `nproc`
 make install
+rm -rf ${WORKPATH}

--- a/src/service/CMakeLists.txt
+++ b/src/service/CMakeLists.txt
@@ -36,11 +36,11 @@ add_custom_command(TARGET udl_signature POST_BUILD
 )
 
 if (ENABLE_MPROC)
-add_library(service OBJECT 
+add_library(service OBJECT
     service.cpp data_flow_graph.cpp _user_defined_logic_interface.cpp
     mproc/mproc_manager_client.cpp)
 else ()
-add_library(service OBJECT 
+add_library(service OBJECT
     service.cpp data_flow_graph.cpp _user_defined_logic_interface.cpp)
 endif()
 target_include_directories(service PRIVATE
@@ -59,7 +59,7 @@ target_include_directories(mproc_manager PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
     $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}>
 )
-target_link_libraries(mproc_manager rpclib::rpc dl pthread)
+target_link_libraries(mproc_manager rpclib::rpc libwsong::ipc dl pthread)
 set_target_properties(mproc_manager PROPERTIES OUTPUT_NAME cascade_mproc_manager)
 endif()
 


### PR DESCRIPTION
The CMakeLists declaration for mproc_manager did not declare its dependency on libwsong::ipc, so the build would fail with the error "wsong/ipc/ring_buffer.ipc could not be found" if libwsong is installed anywhere other than a default system directory like /usr/local/. Adding this declaration fixes it so the target's include path includes the installed location of libwsong when compiling.

Also fixed the install scripts that use mktemp to properly clean up after themselves and delete the temp directory after installing, like I did earlier in Derecho.