### PR TITLE
Updated Cascade to build with spdlog 1.12

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,7 @@ install(DIRECTORY
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(
     "${CMAKE_CURRENT_BINARY_DIR}/cmake/cascadeConfigVersion.cmake"
-    VERSION ${cascade_VERSION}
+    VERSION ${cascade_build_VERSION}
     COMPATIBILITY AnyNewerVersion
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ endif()
 find_package(Readline REQUIRED)
 
 # spdlog_FOUND
-find_package(spdlog 1.3.1 REQUIRED)
+find_package(spdlog 1.12.0 REQUIRED)
 
 # openssl_FOUND
 find_package(OpenSSL REQUIRED)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Please refer to our [paper](https://arxiv.org/pdf/2311.17329) for detailed infor
 # Release status
 As of December 2023, Cascade has the status of a high-quality beta: publicaly available and useable. The current `master` branch allows the development of sophisticated Cascade applications using C/C++ and Python.  Our Cornell deployment and performance evaluation is performed in a cluster computing Ubuntu Linux environment, and we test both with or without RDMA support. The master branch is rapidly approaching the level of stability as we intend for v1.0 release, although more burn-in testing is still required. In January 2024 we anticipate a v1.0 general release of Cascade.
 
-Derecho, used by Cascade, is more mature, with significant use since its initial release in April 2019.  Derecho continues to evolve too, but the rate of new releases is lower.  
+Derecho, used by Cascade, is more mature, with significant use since its initial release in April 2019.  Derecho continues to evolve too, but the rate of new releases is lower.
 
 ## Plan for v1.0
 In January 2024 we anticipate a v1.0 general release of Cascade, based on a stable version of the current `master` branch.    Regression testing is underway on this release right now. Although we have decided to focus on Cascade's core functionality in this first general release, we note that many experimental features are available in v1.0, and can be tested or used by those who are interested.  The experimental functionality includes:
@@ -36,7 +36,7 @@ By early summer of 2024, we anticipate a v1.2 release that would include enhance
 
 Additionally, we are expecting a new set of zero-copy optimizations to be included in this release, including support for the GPUDirect accelerated datapath and zero-copy integration with Derecho's multicast. Improvements more focused on devops will include application packaging, dynamic application management, and monitoring capabilities.
 
-We recommend coordinating with [Weijia Song](mailto:songweijia@gmail.com) if you plan to experiment with beta features of the system.  Anyone planning to do so should also commit to posting issues on the GitHub issue tracker in the event of a bug, with a minimal example that triggers the problem (as few lines of code as you can manage).  
+We recommend coordinating with [Weijia Song](mailto:songweijia@gmail.com) if you plan to experiment with beta features of the system.  Anyone planning to do so should also commit to posting issues on the GitHub issue tracker in the event of a bug, with a minimal example that triggers the problem (as few lines of code as you can manage).
 
 # Using Cascade
 - Cascade can be used both as a service, and as a software library
@@ -72,7 +72,7 @@ We recommend coordinating with [Weijia Song](mailto:songweijia@gmail.com) if you
 | --- | --- |
 | `v1.0.0` | [Commit 982f54a on `master`](https://github.com/Derecho-Project/derecho/commit/982f54a28ae62e85772cb4f071c46c138fd95016) |
 | `v1.0.1` | [v2.4.0](https://github.com/Derecho-Project/derecho/releases/tag/v2.4.0) |
-| `master` HEAD | [v2.4.1rc](https://github.com/Derecho-Project/derecho/releases/tag/v2.4.1rc) |
+| `master` HEAD | [v2.4.1](https://github.com/Derecho-Project/derecho/releases/tag/v2.4.1) |
 
 ## Build Cascade
 1) Download Cascade Source Code

--- a/cascadeConfig.cmake.in
+++ b/cascadeConfig.cmake.in
@@ -2,7 +2,7 @@
 
 include(CMakeFindDependencyMacro)
 find_dependency(derecho)
-find_dependency(spdlog 1.3.1)
+find_dependency(spdlog 1.12.0)
 find_dependency(OpenSSL)
 find_dependency(nlohmann_json 3.9.1)
 find_dependency(rpclib)

--- a/include/cascade/object.hpp
+++ b/include/cascade/object.hpp
@@ -113,7 +113,7 @@ public:
     // bool operator==(const ObjectWithUInt64Key& other);
 
     // constructor 0 : copy constructor
-    ObjectWithUInt64Key(const uint64_t _key, 
+    ObjectWithUInt64Key(const uint64_t _key,
                         const Blob& _blob);
 
     // constructor 0.5 : copy/emplace constructor
@@ -225,11 +225,11 @@ inline std::ostream& operator<<(std::ostream& out, const Blob& b) {
 }
 
 inline std::ostream& operator<<(std::ostream& out, const ObjectWithUInt64Key& o) {
-    out << "ObjectWithUInt64Key{ver: 0x" << std::hex << o.version << std::dec 
-        << ", ts(us): " << o.timestamp_us 
+    out << "ObjectWithUInt64Key{ver: 0x" << std::hex << o.version << std::dec
+        << ", ts(us): " << o.timestamp_us
         << ", prev_ver: " << std::hex << o.previous_version << std::dec
         << ", prev_ver_by_key: " << std::hex << o.previous_version_by_key << std::dec
-        << ", id:" << o.key 
+        << ", id:" << o.key
         << ", data:" << o.blob << "}";
     return out;
 }
@@ -256,7 +256,7 @@ public:
     // bool operator==(const ObjectWithStringKey& other);
 
     // constructor 0 : copy constructor
-    ObjectWithStringKey(const std::string& _key, 
+    ObjectWithStringKey(const std::string& _key,
                         const Blob& _blob);
 
     // constructor 0.5 : copy/in-place constructor
@@ -352,18 +352,19 @@ public:
 };
 
 inline std::ostream& operator<<(std::ostream& out, const ObjectWithStringKey& o) {
-    out << "ObjectWithStringKey{" 
+    out << "ObjectWithStringKey{"
 #ifdef ENABLE_EVALUATION
         << "msg_id: " << o.message_id
 #endif
-        << "ver: 0x" << std::hex << o.version << std::dec 
+        << "ver: 0x" << std::hex << o.version << std::dec
         << ", ts: " << o.timestamp_us
         << ", prev_ver: " << std::hex << o.previous_version << std::dec
         << ", prev_ver_by_key: " << std::hex << o.previous_version_by_key << std::dec
-        << ", id:" << o.key 
+        << ", id:" << o.key
         << ", data:" << o.blob << "}";
     return out;
 }
+
 
 /**
 template <typename KT, typename VT, KT* IK, VT* IV>
@@ -374,3 +375,10 @@ std::enable_if_t<std::disjunction<std::is_same<ObjectWithStringKey,VT>,std::is_s
 
 } // namespace cascade
 } // namespace derecho
+
+// Boilerplate definitions needed to enable debug logging of these objects with the spdlog library
+
+template <>
+struct fmt::formatter<derecho::cascade::ObjectWithUInt64Key> : fmt::ostream_formatter {};
+template <>
+struct fmt::formatter<derecho::cascade::ObjectWithStringKey> : fmt::ostream_formatter {};

--- a/include/cascade/utils.hpp
+++ b/include/cascade/utils.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <mutex>
 #include <condition_variable>
+#include <string>
 #include <time.h>
 #include <thread>
 #include <unordered_set>
@@ -165,7 +166,7 @@ public:
 #ifdef ENABLE_EVALUATION
 /*
  * time logger tags (TLTs)
- * 
+ *
  * We support a wide range of timestamps in cascade for performance tests.
  * For Service Client (Please note that the END time is not logged because the return clause should be included.
  * The callers should measure it by themselves):
@@ -441,7 +442,7 @@ typedef union __attribute__((packed,aligned(8))) action_fire_extra_info {
 /**
  * @class TimestampLogger utils.hpp "cascade/utils.hpp"
  * @brief The timestamp logger tool.
- * 
+ *
  * A wrapper class over the thread-safe timestamp logger in libwsong
  */
 class TimestampLogger {


### PR DESCRIPTION
The next version of Derecho will depend on spdlog 1.12 instead of spdlog 1.9.2, and this library update introduced breaking changes. A few new lines of code are needed to allow Cascade to compile against the Derecho version that uses spdlog 1.12, and Cascade's own CMakeLists should specify that it expects the newer spdlog version (since it will no longer compile against spdlog 1.9.2 with these changes). Once there is a Derecho version that uses the new spdlog, we can merge these changes and create a Cascade version that matches the dependency.