### PR TITLE
Bug fix: Blob copy constructor and BLOB_GENERATOR memory mode

### DIFF
--- a/src/core/object.cpp
+++ b/src/core/object.cpp
@@ -79,7 +79,7 @@ Blob::Blob(const Blob& other) :
     bytes(nullptr), size(0), capacity(0), memory_mode(object_memory_mode_t::DEFAULT) {
     if(other.size > 0) {
         uint8_t* t_bytes = static_cast<uint8_t*>(malloc(other.size));
-        if (memory_mode == object_memory_mode_t::BLOB_GENERATOR) {
+        if (other.memory_mode == object_memory_mode_t::BLOB_GENERATOR) {
             // instantiate data.
             auto number_bytes_generated = other.blob_generator(t_bytes,other.size);
             if (number_bytes_generated != other.size) {


### PR DESCRIPTION
In the Blob copy constructor, if the object being copied has a lambda (instead of a plain buffer), i.e. BLOB_GENERATOR memory mode, the constructor tries to copy from an empty buffer, causing a Segmentation Fault.

The issue is just that the code is checking `memory_mode` from the new object (which is always DEFAULT), not on the other object (that is being copied). 

So it's a very simple fix, I'm merging it to master right away.