### PR TITLE
Implement bytes_size for DeltaStoreCore's DeltaType

### DIFF
--- a/include/cascade/detail/delta_store_core_impl.hpp
+++ b/include/cascade/detail/delta_store_core_impl.hpp
@@ -39,8 +39,14 @@ void DeltaCascadeStoreCore<KT, VT, IK, IV>::DeltaType::post_object(
 
 template <typename KT, typename VT, KT* IK, VT* IV>
 std::size_t DeltaCascadeStoreCore<KT, VT, IK, IV>::DeltaType::bytes_size() const {
-    dbg_default_warn("{} should not be called. It is not designed for serialization.",__PRETTY_FUNCTION__);
-    return 0;
+    size_t delta_size = 0;
+    if (objects.size() > 0) {
+        delta_size += mutils::bytes_size(static_cast<std::size_t>(objects.size()));
+        for (const auto& kv_pair : objects) {
+            delta_size += mutils::bytes_size(kv_pair.second);
+        }
+    }
+    return delta_size;
 }
 
 template <typename KT, typename VT, KT* IK, VT* IV>


### PR DESCRIPTION
While testing my CascadeChain code I saw that the "DeltaType::bytes_size should not be called" warning was being printed by the servers every time I called a function that used Persistent's getDelta, like get() with a specific version. It turns out this is because getDelta passes the DeltaType object to mutils's deserialize_and_run, which internally calls bytes_size after calling from_bytes on its arguments. So DeltaType does have its bytes_size function called during normal operation, even though it is never serialized using to_bytes. 

I implemented bytes_size to compute the same size as currentDeltaSize and currentDeltaToBytes would use (size of a size_t plus size of each object in the objects map), and it works for me. This is a cherry-pick of the change I made on cascade_chain, so it can be merged into the main branch independently of CascadeChain.