### PR TITLE
Update log usage to be compatible with spdlog 1.15

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       run:  >
             sudo apt update;
             sudo apt install libssl-dev librdmacm-dev libibverbs-dev libspdlog-dev -y;
-            sudo apt install libboost-all-dev ragel python3 python3-pip -y
+            sudo apt install libreadline-dev libboost-all-dev ragel python3 python3-pip -y
     - run:  g++ --version
     - run:  cmake --version
     - run:  lscpu

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,9 +13,9 @@ jobs:
     - run:  echo "The job is automatically triggered by a ${{github.event_name}} event."
     - name: "Install APT packages"
       run:  >
-            sudo apt update; 
+            sudo apt update;
             sudo apt install libssl-dev librdmacm-dev libibverbs-dev libspdlog-dev -y;
-            sudo apt install libboost-all-dev ragel python3.10 python3-pip -y
+            sudo apt install libboost-all-dev ragel python3 python3-pip -y
     - run:  g++ --version
     - run:  cmake --version
     - run:  lscpu

--- a/.github/workflows/build_use_zerocopy_delta_api.yml
+++ b/.github/workflows/build_use_zerocopy_delta_api.yml
@@ -15,7 +15,7 @@ jobs:
       run:  >
             sudo apt update;
             sudo apt install libssl-dev librdmacm-dev libibverbs-dev libspdlog-dev -y;
-            sudo apt install libboost-all-dev ragel python3 python3-pip -y
+            sudo apt install libreadline-dev libboost-all-dev ragel python3 python3-pip -y
     - run:  g++ --version
     - run:  cmake --version
     - run:  lscpu

--- a/.github/workflows/build_use_zerocopy_delta_api.yml
+++ b/.github/workflows/build_use_zerocopy_delta_api.yml
@@ -13,9 +13,9 @@ jobs:
     - run:  echo "The job is automatically triggered by a ${{github.event_name}} event."
     - name: "Install APT packages"
       run:  >
-            sudo apt update; 
+            sudo apt update;
             sudo apt install libssl-dev librdmacm-dev libibverbs-dev libspdlog-dev -y;
-            sudo apt install libboost-all-dev ragel python3.10 python3-pip -y
+            sudo apt install libboost-all-dev ragel python3 python3-pip -y
     - run:  g++ --version
     - run:  cmake --version
     - run:  lscpu

--- a/include/cascade/service.hpp
+++ b/include/cascade/service.hpp
@@ -52,7 +52,7 @@ namespace cascade {
     constexpr bool have_same_object_type() {
         return true;
     }
-    
+
     /**
      * @fn constexpr bool have_same_object_type()
      * @tparam  FirstCascadeType
@@ -361,6 +361,8 @@ namespace cascade {
     // #define DEFAULT_SHARD_MEMBER_SELECTION_POLICY (ShardMemberSelectionPolicy::FirstMember)
     #define DEFAULT_SHARD_MEMBER_SELECTION_POLICY (ShardMemberSelectionPolicy::RoundRobin)
 
+    std::ostream& operator<<(std::ostream& stream, const ShardMemberSelectionPolicy& policy);
+
     template <typename T> struct do_hash {};
 
     template <> struct do_hash<std::tuple<std::type_index,uint32_t,uint32_t>> {
@@ -660,7 +662,7 @@ namespace cascade {
          * @param[in] object_pool_pathname  - the object pool name
          */
         uint32_t get_number_of_shards(const std::string& object_pool_pathname);
-   
+
         template <typename SubgroupType>
         int32_t get_my_shard(uint32_t subgroup_index) const;
     protected:
@@ -796,7 +798,7 @@ namespace cascade {
          * @param[in] type_index    the index of the subgroup type in the CascadeTypes... list. and the FirstType,
          *                          SecondType, .../ RestTypes should be in the same order.
          * @param[in] object        the object to write
-         * @param[in] subgroup_index    
+         * @param[in] subgroup_index
          *                          the subgroup index in the subgroup type designated by type_index
          * @param[in] shard_index   the shard index
          * @param[in] as_trigger    If true, the object will NOT apply to the K/V store. The object will only be
@@ -1735,7 +1737,7 @@ namespace cascade {
     struct PrefixOCDPOInfoCompare {
         // inline bool operator() (const prefix_ocdpo_info_t& l, const prefix_ocdpo_info_t& r) const {
         bool operator() (const prefix_ocdpo_info_t& l, const prefix_ocdpo_info_t& r) const {
-            return (l.udl_id == r.udl_id) && 
+            return (l.udl_id == r.udl_id) &&
                    (l.config_string == r.config_string) &&
                    (l.execution_environment == r.execution_environment);
         }
@@ -1937,5 +1939,9 @@ namespace cascade {
     };//ExecutionEngine/
 } // cascade
 } // derecho
+
+// Formatter boilerplate for the spdlog library
+template <>
+struct fmt::formatter<derecho::cascade::ShardMemberSelectionPolicy> : fmt::ostream_formatter {};
 
 #include "detail/service_impl.hpp"

--- a/src/service/perftest.cpp
+++ b/src/service/perftest.cpp
@@ -1150,6 +1150,21 @@ PerfTestServer::~PerfTestServer() {
 // PerfTestClient implementation    //
 //////////////////////////////////////
 
+std::ostream& operator<<(std::ostream& os, PutType pt) {
+    switch(pt) {
+        case PutType::PUT:
+            os << "PUT";
+            break;
+        case PutType::PUT_AND_FORGET:
+            os << "PUT_AND_FORGET";
+            break;
+        case PutType::TRIGGER_PUT:
+            os << "TRIGGER_PUT";
+            break;
+    }
+    return os;
+}
+
 PerfTestClient::PerfTestClient(ServiceClientAPI& capi):capi(capi) {}
 
 void PerfTestClient::add_or_update_server(const std::string& host, uint16_t port) {

--- a/src/service/perftest.hpp
+++ b/src/service/perftest.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <cascade/service_client_api.hpp>
+#include <iostream>
 #include <limits>
 #include <rpc/server.h>
 #include <rpc/client.h>
@@ -175,6 +176,8 @@ enum PutType {
     PUT_AND_FORGET, // put and forget
     TRIGGER_PUT     // trigger put
 };
+
+std::ostream& operator<<(std::ostream& os, PutType pt);
 
 class PerfTestClient {
 private:
@@ -778,3 +781,7 @@ bool PerfTestClient::perf_get_by_time(uint32_t subgroup_index,
 }
 }
 }
+
+// Formatter boilerplate for the spdlog library
+template <>
+struct fmt::formatter<derecho::cascade::PutType> : fmt::ostream_formatter {};

--- a/src/service/service.cpp
+++ b/src/service/service.cpp
@@ -4,8 +4,41 @@
 namespace derecho {
 namespace cascade {
 
-/** 
- * cpu/gpu list examples: 
+
+std::ostream& operator<<(std::ostream& stream, const ShardMemberSelectionPolicy& policy) {
+    switch(policy) {
+        case ShardMemberSelectionPolicy::FirstMember:
+            stream << "FirstMember";
+            break;
+        case ShardMemberSelectionPolicy::LastMember:
+            stream << "LastMember";
+            break;
+        case ShardMemberSelectionPolicy::Random:
+            stream << "Random";
+            break;
+        case ShardMemberSelectionPolicy::FixedRandom:
+            stream << "FixedRandom";
+            break;
+        case ShardMemberSelectionPolicy::RoundRobin:
+            stream << "RoundRobin";
+            break;
+        case ShardMemberSelectionPolicy::KeyHashing:
+            stream << "KeyHashing";
+            break;
+        case ShardMemberSelectionPolicy::UserSpecified:
+            stream << "UserSpecified";
+            break;
+        case ShardMemberSelectionPolicy::InvalidPolicy:
+        default:
+            stream << "InvalidPolicy";
+            break;
+    }
+    return stream;
+}
+
+
+/**
+ * cpu/gpu list examples:
  * cpu_cores = 0,1,2,3
  * cpu_cores = 0,1-5,6,8
  * cpu_cores = 0-15


### PR DESCRIPTION
The latest version of spdlog (1.15) depends on a newer version of fmt (11.1) that no longer has a default format behavior for enum types. To maintain compatibility with spdlog 1.15, all enum types must have a formatter specialization, or logger calls with enum values must wrap the enum values in `fmt::underlying()` to re-enable the old behavior of printing the integer value of the enum.

This change is backward-compatible with spdlog 1.12, so there's no need to increase our minimum required version.